### PR TITLE
Clarify that repeated M3 messages are allowed if expired

### DIFF
--- a/bip300.md
+++ b/bip300.md
@@ -231,8 +231,9 @@ following conditions hold:
 Otherwise, an M3 message is considered _valid_.
 If any of the following conditions hold, the block is considered _invalid_ and
 MUST be _rejected_:
-* The `32`-byte `M6ID` has already been proposed in an M3
-  message in a previous block, that has not been paid out.
+* The `32`-byte `M6ID` is still pending for the specified sidechain slot. An
+  `M6ID` that is no longer pending MAY be proposed again, initializing a fresh
+  ACK counter and expiry block height.
 * Another _valid_ M3 message with an identical sidechain slot number is
   included within any coinbase output at a lower output index.
 
@@ -926,8 +927,17 @@ Where `S` is the sidechain slot number, and where `PendingM6id` is defined as
 pub struct PendingM6id {
     pub m6id: Hash256,
     pub vote_count: u16,
+    pub proposal_height: u32,
 }
 ```
+
+An `M6ID` is _pending_ for sidechain slot `S` while it is present in
+`sidechain_number_to_pending_m6ids[S]`. It is added when proposed by a _valid_
+M3 message (per the M3 specification), and removed when it is either:
+
+* _paid out_ — an `M6` whose `m6_to_id` equals this `M6ID` is included, or
+* _expired_ — its `age` exceeds `WITHDRAWAL_BUNDLE_MAX_AGE`, where `age =
+  current_block_height - proposal_height`.
 
 # Validation Rules specification
 ## Transaction Validation Rules specification


### PR DESCRIPTION
A strict reading of the spec would mean that M6IDs could never be repeated, even if the M3 bundle expired. This is not intentional. Bundles should be re-submittable, starting over again at 0 ACKs.