### PR TITLE
Flip byte order for M4 messages

### DIFF
--- a/bip300.md
+++ b/bip300.md
@@ -341,7 +341,7 @@ type of the elements of this array `A` is determined by the exact version.
 
 For `VOTES_ONE_BYTE` we MUST interpret `A` as an array of 8 bit unsigned
 integers, for `VOTES_TWO_BYTE` we MUST interpret `A` as an array of 16 bit
-unsigned integers encoded in big endian byte order.
+unsigned integers encoded in little endian byte order.
 
 The index `i` of an element in array `A` determines the sidechain slot. Active
 sidechain slot numbers MAY have gaps between them, so we can't use the index as
@@ -406,7 +406,7 @@ determined by `i` in the following way:
    of range error?
 
 For the `VOTES_TWO_BYTE` version of M4 an element of `A` at index `i`, which is
-a 16 bit unsigned integer encoded in big endian byte order, MUST be interpreted
+a 16 bit unsigned integer encoded in little endian byte order, MUST be interpreted
 in the following way:
 
 Value `A[i] == 65534 // 0xFFFE` means `ALARM`, and it MUST be interpreted as defined


### PR DESCRIPTION
The enforcer implemented reading M4 messages in little endian byte order. Considering that the enforcer is currently the only implementer of the spec, we figured it was easiest to just change the spec.

https://github.com/LayerTwo-Labs/bip300301_enforcer/issues/328