### PR TITLE
Format files with oxfmt, add check to CI

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Format files with oxfmt, add check to CI
+d60e52b87015a8ae39d84c22cf07726ae9093637

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,16 @@
+name: Format
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  oxfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - uses: extractions/setup-just@v2
+      - run: just fmt
+      - run: git diff --exit-code

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,5 @@
+{
+  "proseWrap": "always",
+  "printWidth": 80,
+  "ignorePatterns": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "oxc.fmt.configPath": ".oxfmtrc.json",
+  "[markdown]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.formatOnSave": true
+  },
+  "[json]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.formatOnSave": true
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.formatOnSave": true
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode",
+    "editor.formatOnSave": true
+  }
+}

--- a/bip300.md
+++ b/bip300.md
@@ -1,10 +1,10 @@
 BIP-300 Protocol Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in RFC 2119.
 
-TODO: Reconsider the format.
+TODO: Reconsider the format.  
 TODO: Edit the specification to be in uniform style.
 
 # Constants
@@ -24,6 +24,7 @@ UNUSED_SIDECHAIN_SLOT_ACTIVATION_THRESHOLD = UNUSED_SIDECHAIN_SLOT_PROPOSAL_MAX_
 ```
 
 # Message headers
+
 ```
 M1: [0xD5, 0xE0, 0xC4, 0xAF]
 M2: [0xD6, 0xE1, 0xC5, 0xBF]
@@ -51,8 +52,8 @@ If the sidechain slot is `used`, then I propose for the sidechain it is
 currently `used` by to be overwritten by a new sidechain described by `D`.
 
 After the old sidechain is overwritten, it will no longer be officially
-possible, as far as the BIP300 protocol is concerned, to make deposits to and
-to make withdrawals from the old sidechain, the old sidechain software may do
+possible, as far as the BIP300 protocol is concerned, to make deposits to and to
+make withdrawals from the old sidechain, the old sidechain software may do
 whatever it wants in this new unofficial condition.
 
 After the new sidechain overwrites the old one, it will be possible to make
@@ -61,6 +62,7 @@ deposits to and withdrawals from the new sidechain described by `D`.
 The voting thresholds for overwriting a sidechain in `used` sidechain slot are
 different form the voting thresholds for activating a sidechain in an `unused`
 sidechain slot. The voting thresholds are defined in the section specifying M2
+
 - ACK Sidechain Proposal.
 
 ## Definition
@@ -77,10 +79,11 @@ the subsequent Encoding section.
 
 A sidechain description is an array of bytes.
 
-The exact representation of this array of bytes in the actual M1 message is defined in
-the subsequent Encoding section.
+The exact representation of this array of bytes in the actual M1 message is
+defined in the subsequent Encoding section.
 
 ## Encoding
+
 The M1 script MUST be included in an output of a coinbase transaction. An M1
 script that is not an output of a coinbases transaction MUST be ignored.
 
@@ -98,7 +101,7 @@ please.
 class CTxOut
 {
 public:
-    CAmount nValue; // nValue MUST be ignored. 
+    CAmount nValue; // nValue MUST be ignored.
     CScript scriptPubKey; // M1 MUST be encoded in scriptPubKey.
 // ...
 }
@@ -113,16 +116,17 @@ OP_RETURN [0xD5, 0xE0, 0xC4, 0xAF] <S> <D>
 Bitcoin script interpreter fails immediately upon seeing an OP_RETURN, meaning
 that the output is unspendable no matter what comes after OP_RETURN.
 
-For the purposes of BIP300 protocol we shall reinterpret the bytes following
-an OP_RETURN as just bytes, not as Bitcoins script opcodes.
+For the purposes of BIP300 protocol we shall reinterpret the bytes following an
+OP_RETURN as just bytes, not as Bitcoins script opcodes.
 
-So the bytes after an OP_RETURN MUST be interpreted just as bytes with absolutely
-no semantic connection to Bitcoin script.
+So the bytes after an OP_RETURN MUST be interpreted just as bytes with
+absolutely no semantic connection to Bitcoin script.
 
-If a scriptPubKey is an OP_RETURN = `0x6A` followed by the four bytes `[0xD5, 0xE0,
-0xC4, 0xAF]`, then it MUST be interpreted as an M1 message.
+If a scriptPubKey is an OP_RETURN = `0x6A` followed by the four bytes
+`[0xD5, 0xE0, 0xC4, 0xAF]`, then it MUST be interpreted as an M1 message.
 
 So the boolean expression
+
 ```
    scriptPubKey[0] == 0x6A // OP_RETURN
 && scriptPubKey[1] == 0xD5
@@ -130,6 +134,7 @@ So the boolean expression
 && scriptPubKey[3] == 0xC4
 && scriptPubKey[4] == 0xAF
 ```
+
 evaluating to true means that it is an M1 message.
 
 `[0x6A, 0xD5, 0xE0, 0xC4, 0xAF]` is the header of M1.
@@ -146,13 +151,15 @@ in an `unused` slot or that will overwrite the old sidechain that was occupying
 a `used` slot.
 
 `S` is a single byte it is always the byte at index 5. So in pseudocode:
+
 ```
 S = scriptPubKey[5]
 ```
 
-`D` is an array consisting of all the bytes following `S`, so all the bytes
-from index 6 (including the byte at index 6)  until the end of the script. In
+`D` is an array consisting of all the bytes following `S`, so all the bytes from
+index 6 (including the byte at index 6) until the end of the script. In
 pseudocode:
+
 ```
 D = scriptPubKey[6..]
 ```
@@ -164,8 +171,8 @@ validation rules.
 
 M1 MUST be a Bitcoin script valid under existing validation rules, meaning that
 no matter what sidechain slot is chosen and no matter what the bytes in the
-array of the sidechain description - a coinbase transaction containing an
-output with an M1 encoded in its scriptpubkey MUST be accepted by ANY currently
+array of the sidechain description - a coinbase transaction containing an output
+with an M1 encoded in its scriptpubkey MUST be accepted by ANY currently
 deployed Bitcoin node with a reasonable configuration - including nodes that do
 enforce BIP300 rules and the ones that don't both.
 
@@ -173,16 +180,18 @@ An analogous condition applies to ALL subsequent messages - to M2, M3, M4, M5,
 M6.
 
 # M2. "ACK Proposal"
-## Semantics
-An M2 message SHALL be interpreted as an ordinary script if any of the
-following conditions hold:
 
-* The M2 message is not within a coinbase output.
-* The M2 message is NOT _well-formed_, ie. NOT composed of exactly `38` bytes.
-* The `32`-byte proposal identifier does not match the sha256d digest of any
+## Semantics
+
+An M2 message SHALL be interpreted as an ordinary script if any of the following
+conditions hold:
+
+- The M2 message is not within a coinbase output.
+- The M2 message is NOT _well-formed_, ie. NOT composed of exactly `38` bytes.
+- The `32`-byte proposal identifier does not match the sha256d digest of any
   sidechain proposal created via an M1 message in a previous block.
 
-Otherwise, an M2 message is considered _valid_. 
+Otherwise, an M2 message is considered _valid_.
 
 If another _valid_ M2 message is included within any coinbase output at a lower
 output index, the block is _invalid_ and MUST be _rejected_. Otherwise, a node
@@ -192,15 +201,15 @@ digest is referenced by the `32`-byte proposal identifier.
 If any of the following conditions hold, activation for the specified sidechain
 proposal _fails_:
 
-* The sidechain proposal refers to an unused slot, and the sidechain proposal
+- The sidechain proposal refers to an unused slot, and the sidechain proposal
   age is greater than `UNUSED_SIDECHAIN_SLOT_PROPOSAL_MAX_AGE` blocks
-* The sidechain proposal refers to an unused slot, the sidechain proposal age
-  is greater than `UNUSED_SIDECHAIN_SLOT_ACTIVATION_MAX_FAILS` blocks, and the
-  difference between the ACK counter for the proposal and the sidechain
-  proposal age is not less than `UNUSED_SIDECHAIN_SLOT_ACTIVATION_MAX_FAILS`.
-* The sidechain proposal refers to a used slot, and the sidechain proposal age
+- The sidechain proposal refers to an unused slot, the sidechain proposal age is
+  greater than `UNUSED_SIDECHAIN_SLOT_ACTIVATION_MAX_FAILS` blocks, and the
+  difference between the ACK counter for the proposal and the sidechain proposal
+  age is not less than `UNUSED_SIDECHAIN_SLOT_ACTIVATION_MAX_FAILS`.
+- The sidechain proposal refers to a used slot, and the sidechain proposal age
   is greater than `USED_SIDECHAIN_SLOT_PROPOSAL_MAX_AGE` blocks
-* The sidechain proposal refers to an used slot, the sidechain proposal age is
+- The sidechain proposal refers to an used slot, the sidechain proposal age is
   greater than `USED_SIDECHAIN_SLOT_ACTIVATION_MAX_FAILS` blocks, and the
   difference between the ACK counter for the proposal and the sidechain proposal
   age is not less than `USED_SIDECHAIN_SLOT_ACTIVATION_MAX_FAILS`.
@@ -209,53 +218,65 @@ If none of the conditions for failure are possible, the sidechain proposal
 _succeeds_, and the sidechain described by the proposal is _activated_.
 
 ## Definition
+
 ## Encoding
-M2 scripts are defined as scripts with the prefix `OP_RETURN [0xD6, 0xE1, 0xC5, 0xBF]`.
-A _well-formed_ M2 script is defined as a script of the form
-`OP_RETURN [0xD6, 0xE1, 0xC5, 0xBF] <S> <ACK>` where `S` is exactly 1 byte and
-`ACK` is exactly `32` bytes.
+
+M2 scripts are defined as scripts with the prefix
+`OP_RETURN [0xD6, 0xE1, 0xC5, 0xBF]`. A _well-formed_ M2 script is defined as a
+script of the form `OP_RETURN [0xD6, 0xE1, 0xC5, 0xBF] <S> <ACK>` where `S` is
+exactly 1 byte and `ACK` is exactly `32` bytes.
 
 `S` is sidechain slot number for which the sidechain described by `D` is
-proposed.
-`ACK` is the sha256d hash of the sidechain proposal description `D`.
+proposed. `ACK` is the sha256d hash of the sidechain proposal description `D`.
 
 ## Conditions
+
 # M3. "Propose Bundle"
+
 ## Semantics
-An M3 message SHALL be interpreted as an ordinary script if any of the
-following conditions hold:
-* The M3 message is not within a coinbase output.
-* The M3 message is NOT _well-formed_, ie. NOT composed of exactly `38` bytes.
-* The `1`-byte sidechain slot number does not correspond to a sidechain slot
+
+An M3 message SHALL be interpreted as an ordinary script if any of the following
+conditions hold:
+
+- The M3 message is not within a coinbase output.
+- The M3 message is NOT _well-formed_, ie. NOT composed of exactly `38` bytes.
+- The `1`-byte sidechain slot number does not correspond to a sidechain slot
   that is _active_.
 
-Otherwise, an M3 message is considered _valid_.
-If any of the following conditions hold, the block is considered _invalid_ and
-MUST be _rejected_:
-* The `32`-byte `M6ID` is still pending for the specified sidechain slot. An
+Otherwise, an M3 message is considered _valid_. If any of the following
+conditions hold, the block is considered _invalid_ and MUST be _rejected_:
+
+- The `32`-byte `M6ID` is still pending for the specified sidechain slot. An
   `M6ID` that is no longer pending MAY be proposed again, initializing a fresh
   ACK counter and expiry block height.
-* Another _valid_ M3 message with an identical sidechain slot number is
-  included within any coinbase output at a lower output index.
+- Another _valid_ M3 message with an identical sidechain slot number is included
+  within any coinbase output at a lower output index.
 
 If a _valid_ M3 message does not cause a block to be considered _invalid_, a
-node MUST initialize an ACK counter and expiry block height corresponding to
-the pair consisting of the specified sidechain slot, and the  `32`-byte `M6ID`,
-where the initial value of the ACK counter is `1`, and the initial value of the
-expiry block height is the `WITHDRAWAL_BUNDLE_MAX_AGE - 1` greater than the
-block height of the block that includes the M3 message.
+node MUST initialize an ACK counter and expiry block height corresponding to the
+pair consisting of the specified sidechain slot, and the `32`-byte `M6ID`, where
+the initial value of the ACK counter is `1`, and the initial value of the expiry
+block height is the `WITHDRAWAL_BUNDLE_MAX_AGE - 1` greater than the block
+height of the block that includes the M3 message.
 
 ## Definition
+
 ## Encoding
-M3 scripts are defined as scripts with the prefix `OP_RETURN [0xD4, 0x5A, 0xA9,
-0x43]`. A _well-formed_ M3 script is defined as a script of the form
+
+M3 scripts are defined as scripts with the prefix
+`OP_RETURN [0xD4, 0x5A, 0xA9, 0x43]`. A _well-formed_ M3 script is defined as a
+script of the form
+
 ```
 OP_RETURN [0xD4, 0x5A, 0xA9, 0x43] <S> <M6ID>
 ```
+
 where `S` is exactly `1` byte, and `M6ID` is an array of exactly `32` bytes.
 
 ## Conditions
+
 # M4. "Ack Bundle"
+
 ## Semantics
 
 An M4 can have 4 different version.
@@ -263,10 +284,12 @@ An M4 can have 4 different version.
 `M4 = REPEAT_PREVIOUS_M4 | VOTES_ONE_BYTE | VOTES_TWO_BYTE | UPVOTE_LEADING_BY_50`.
 
 The `REPEAT_PREVIOUS_M4` version of M4 MUST be interpreted as its name suggests
+
 - execute the previously executed M4 again.
 
 The `UPVOTE_LEADING_BY_50` version of M4 MUST be interpreted as its name
 suggests. In pseudo code:
+
 ```
 for each sidechain slot
 
@@ -283,8 +306,8 @@ for each sidechain slot
 ```
 
 The differences between the `VOTES_ONE_BYTE` version and the `VOTES_TWO_BYTE`
-version are specified in the encoding section. Semantically they are exactly
-the same.
+version are specified in the encoding section. Semantically they are exactly the
+same.
 
 An M4 of one of the two `VOTES_*` versions contains a list of sidechain slots
 `S_0`, `S_1`, ..., `S_n`.
@@ -298,7 +321,7 @@ A vote `V_i` MUST be interpreted in the following way.
    downvoted (vote count of each decremented by 1).
 2. If it is an `Abstain` then the vote counts of all `M6ID`s in `S_i` MUST
    remain unchanged.
-2. If it is an `Alarm` then the vote counts of all `M6ID`s in `S_i` MUST be
+3. If it is an `Alarm` then the vote counts of all `M6ID`s in `S_i` MUST be
    downvoted (vote count of each decremented by 1).
 
 The exact data structure to be used for storing `M6ID`s in active sidechain
@@ -313,6 +336,7 @@ Corresponding here means that `m6_to_id(M6) = M6ID`, where `m6_to_id` is the
 function defined in the section specifying `M6`.
 
 ## Definition
+
 ## Encoding
 
 An M4 MUST be included in an output of a coinbase transaction.
@@ -324,8 +348,8 @@ OP_RETURN [0xD7, 0x7D, 0x17, 0x76] V Option<A>
 ```
 
 Where `[0xD7, 0x7D, 0x17, 0x76]` is the M4 header identifying this script as an
-M4, `V` is the byte that determines the version of the M4 encoded in the
-script:
+M4, `V` is the byte that determines the version of the M4 encoded in the script:
+
 ```
 V == 0 -- REPEAT_PREVIOUS_M4
 V == 1 -- VOTES_ONE_BYTE
@@ -334,8 +358,8 @@ V == 3 -- UPVOTE_LEADING_BY_50
 ```
 
 If `V == 0` or `V == 3`, meaning if it is the `REPEAT_PREVIOUS_M4` version or
-the `UPVOTE_LEADING_BY_50` version, then nothing follows the `V` byte, so the script
-MUST be exactly 6 bytes long.
+the `UPVOTE_LEADING_BY_50` version, then nothing follows the `V` byte, so the
+script MUST be exactly 6 bytes long.
 
 If `V == 1` or `V == 2`, meaning if it is the `VOTES_ONE_BYTE` version or the
 `VOTES_TWO_BYTE` version, then the `V` byte is followed by the array `A`, the
@@ -350,22 +374,23 @@ sidechain slot numbers MAY have gaps between them, so we can't use the index as
 the actual sidechain slot number.
 
 Instead we:
+
 1. Take all the active sidechain slot numbers and put them in a vector `ASN`,
    for active slot numbers.
-2. Sort the sidechain slot numbers in the vector in ascending order, so `[10,
-   1, 19, 3]` after sorting would become `[1, 3, 10, 19]`. So now the `ASN`
-   vector is sorted in ascending order.
-3. Index the sorted `ASN` vector with `i`. For example if `ASN = [1, 3, 10,
-   19]` and `i = 2`, then `ASN[i] == ASN[2] == 10`, so the element at index `i
-   == 2` of `A` corresponds to sidechain slot 10.
+2. Sort the sidechain slot numbers in the vector in ascending order, so
+   `[10, 1, 19, 3]` after sorting would become `[1, 3, 10, 19]`. So now the
+   `ASN` vector is sorted in ascending order.
+3. Index the sorted `ASN` vector with `i`. For example if `ASN = [1, 3, 10, 19]`
+   and `i = 2`, then `ASN[i] == ASN[2] == 10`, so the element at index `i == 2`
+   of `A` corresponds to sidechain slot 10.
 
 If the `A.len() > ASN.len()`, then this M4 MUST be considered invalid, and the
 whole block this M4 is included in MUST be considered invalid as well, because
 we are attempting to set withdrawal bundle votes for sidechain slots that are
 not active.
 
-??? QUESTION: Does the above make sense? Would it be better to ignore the
-excess votes in `A`?
+??? QUESTION: Does the above make sense? Would it be better to ignore the excess
+votes in `A`?
 
 The actual element `A[i]` is either an 8 bit or a 16 bit unsigned integer,
 depending on the M4 version.
@@ -382,37 +407,37 @@ defined in the semantics section above.
 For values of `A[i]` from `0` to `253` inclusively it uniquely identifies one
 `M6ID` out of potentially many `M6ID`s which were previously proposed by `M3`s
 for the sidechain slot determined by index `i` (see the algorithm above to see
-    how to get the sidechain slot number from `i`).
+how to get the sidechain slot number from `i`).
 
 This value of `A[i]` MUST be mapped to the actual `M6ID` in sidechain slot
 determined by `i` in the following way:
 
 1. Take all `M6ID`s currently in this sidechain slot and put them in a vector.
-2. Sort all these `M6ID`s chronologically in ascending order by the block
-   number of the block they were included in. The oldest (the one with the
-   lowest inclusion block number) `M6ID` would have the index `0` in this
-   vector, second oldest would have index `1`, etc.
+2. Sort all these `M6ID`s chronologically in ascending order by the block number
+   of the block they were included in. The oldest (the one with the lowest
+   inclusion block number) `M6ID` would have the index `0` in this vector,
+   second oldest would have index `1`, etc.
 3. It is possible for two `M3`s proposing two different `M6ID`s for the same
    sidechain slot to be included in the same block, so it is possible for two
    different `M6ID`s to have the same inclusion block number. In these cases
    their order in the sorted vector MUST be the same as their order in the
    coinbase `vout` vector. Let us call this chronologically sorted vector
    `M6IDS_chronological`.
-4. Get the actual `M6ID` value by indexing the sorted vector `M6ID =
-   M6IDS_chronological[A[i]]`. Then we MUST upvote this `M6ID` as defined in
-   the semantics section above. If there is no `M6ID` in the
+4. Get the actual `M6ID` value by indexing the sorted vector
+   `M6ID = M6IDS_chronological[A[i]]`. Then we MUST upvote this `M6ID` as
+   defined in the semantics section above. If there is no `M6ID` in the
    `M6IDS_chronological` at index `A[i]` (index out of range error), then this
    M4 along with the block it is included in MUST be considered invalid.
 
-   ??? QUESTION: Would it make more sense to ignore the M4 with the index out
-   of range error?
+   ??? QUESTION: Would it make more sense to ignore the M4 with the index out of
+   range error?
 
 For the `VOTES_TWO_BYTE` version of M4 an element of `A` at index `i`, which is
-a 16 bit unsigned integer encoded in little endian byte order, MUST be interpreted
-in the following way:
+a 16 bit unsigned integer encoded in little endian byte order, MUST be
+interpreted in the following way:
 
-Value `A[i] == 65534 // 0xFFFE` means `ALARM`, and it MUST be interpreted as defined
-in the semantics section above.
+Value `A[i] == 65534 // 0xFFFE` means `ALARM`, and it MUST be interpreted as
+defined in the semantics section above.
 
 Value `A[i] == 65535 // 0xFFFF` means `ABSTAIN`, and it MUST be interpreted as
 defined in the semantics section above.
@@ -420,7 +445,7 @@ defined in the semantics section above.
 For values of `A[i]` from `0` to `65533` inclusively it uniquely identifies one
 `M6ID` out of potentially many `M6ID`s which were previously proposed by `M3`s
 for the sidechain slot determined by index `i` (see the algorithm above to see
-    how to get the sidechain slot number from `i`).
+how to get the sidechain slot number from `i`).
 
 The procedure for getting the actual `M6ID` from the element `A[i]` is exactly
 the same as the one defined above for the `VOTES_ONE_BYTE` version. The only
@@ -436,9 +461,11 @@ the 16 bit version when the 8 bit version would suffice.
 ??? QUESTION: Does it make sense to enforce this rule?
 
 ## Conditions
+
 # M5. "Deposit"
 
 ## Semantics
+
 An M5 with sidechain slot number S, value V, and address A means:
 
 I, a Bitcoin user with sufficient funds, deposit V sats to address A to the
@@ -450,13 +477,14 @@ all funds currently in circulation on the sidechain in slot S.
 
 An M5 is a Bitcoin transaction.
 
-M5 for sidechain slot S MUST either create the first treasury UTXO for
-sidechain slot S or, if it already exists, spend the treasury UTXO for
-sidechain slot S and then create a new one.
+M5 for sidechain slot S MUST either create the first treasury UTXO for sidechain
+slot S or, if it already exists, spend the treasury UTXO for sidechain slot S
+and then create a new one.
 
 There MUST never be two treasury UTXOs for the same sidechain slot.
 
 ## Definition
+
 ## Encoding
 
 M5 MUST be a valid Bitcoin transaction.
@@ -465,8 +493,8 @@ M5 MUST have the following three parts:
 
 1. treasury UTXO
 2. address OP_RETURN output
-3. input spending previous treasury UTXO (if it is not the first ever deposit
-   to this sidechain)
+3. input spending previous treasury UTXO (if it is not the first ever deposit to
+   this sidechain)
 
 Let us consider these three parts in turn.
 
@@ -529,8 +557,8 @@ the `n`th deposit.
 
 ### address OP_RETURN output
 
-`nValue` of the address OP_RETURN output MUST be ignored, Bitcoin users are
-free to dispose of their funds as they please.
+`nValue` of the address OP_RETURN output MUST be ignored, Bitcoin users are free
+to dispose of their funds as they please.
 
 An address OP_RETURN output MUST have a `scriptPubKey` of the following form
 
@@ -539,8 +567,8 @@ OP_RETURN <A>
 ```
 
 Where `A` is an array of bytes encoding the sidechain address for the deposit.
-Interpretation of `A` for a particular sidechain slot is up to the authors of the
-sidechain active in that slot.
+Interpretation of `A` for a particular sidechain slot is up to the authors of
+the sidechain active in that slot.
 
 `A` MUST be interpreted by the BIP300 enforcer software as an arbitrary
 meaningless array of bytes.
@@ -555,8 +583,8 @@ public:
 }
 ```
 
-An address OP_RETURN output MUST come immediately after the treasury UTXO in
-the `vout` vector of the M5 transaction.
+An address OP_RETURN output MUST come immediately after the treasury UTXO in the
+`vout` vector of the M5 transaction.
 
 ```C++
 class CTransaction
@@ -573,13 +601,14 @@ transaction, then the corresponding address OP_RETURN output MUST be at the
 index 6.
 
 In pseudocode the following boolean expression MUST be true for any valid M5:
+
 ```
    vout[i] == OP_DRIVECHAIN OP_PUSHBYTES_1 <S> OP_TRUE
 && vout[i+1] == OP_RETURN <A>
 ```
 
-If an M5 transaction has a UTXO treasury output and no address OP_RETURN
-output, then it MUST be considered invalid by the BIP300 enforcer software.
+If an M5 transaction has a UTXO treasury output and no address OP_RETURN output,
+then it MUST be considered invalid by the BIP300 enforcer software.
 
 ### input spending previous UTXO treasury output
 
@@ -654,8 +683,7 @@ public:
 }
 ```
 
-We know `S`, `T_1`, and `A_0`.
-We can compute `V_0 = T_1 - T_0 = T_1 - 0 = T_1`.
+We know `S`, `T_1`, and `A_0`. We can compute `V_0 = T_1 - T_0 = T_1 - 0 = T_1`.
 Now we know all three parts we need `S`, `V_0`, and `A_0`.
 
 So we have recovered the `n = 0` deposit made to the sidechain slot `S`.
@@ -663,8 +691,7 @@ So we have recovered the `n = 0` deposit made to the sidechain slot `S`.
 A deposit with `n > 0` is different, in order to recover it we shall need two
 Bitcoin transactions `M5_n` and `M5_n-1`.
 
-We can get `S`, `A_n`, and `T_n+1` from `M5_n`.
-We can get `T_n` from `M5_n-1`.
+We can get `S`, `A_n`, and `T_n+1` from `M5_n`. We can get `T_n` from `M5_n-1`.
 Then we can get `V_n = T_n+1 - T_n`.
 
 So each deposit with `n > 0` is encoded by a pair of Bitcoin transactions.
@@ -678,13 +705,13 @@ M5_3, M5_4 -- n = 4
 ...
 ```
 
-///
+///  
 TODO: Specify how M6 withdrawal bundles, which have `T_n < T_n-1`, are to be
 handled. Do we skip them, so the deposit sequence numbers remain continuous, or
 do we count them, so there are gaps in the deposit sequence numbers?
 
-I think it makes more sense to count them, so we know at which sequence number
-a withdrawal happened.
+I think it makes more sense to count them, so we know at which sequence number a
+withdrawal happened.
 
 If we attempt to look up a deposit at a withdrawal sequence number, the BIP300
 enforcer deposits database would just say "a withdrawal happened at this
@@ -692,7 +719,7 @@ sequence number".
 
 It would also make sense to store mainchain block height, at which M5 or M6 was
 included, alongside the corresponding sequence number in the BIP300 enforcer
-database.
+database.  
 ///
 
 It is also important to keep track of `n` - the deposit sequence number, so in
@@ -704,9 +731,9 @@ sidechain slots, because otherwise we would have to rescan the whole Bitcoin
 blockchain every time we need to look up a deposit.
 
 It would also make sense for the BIP300 enforcer software to keep track of last
-`T_n` for every sidechain slot `S`, so whenever it receives `M5_n` encoding
-`S`, `T_n+1`, and `A_n` it can compute `V_n = T_n+1 - T_n` and thus get all
-four parts `n`, `S`, `V_n`, and `A_n` it needs in order to update its deposits
+`T_n` for every sidechain slot `S`, so whenever it receives `M5_n` encoding `S`,
+`T_n+1`, and `A_n` it can compute `V_n = T_n+1 - T_n` and thus get all four
+parts `n`, `S`, `V_n`, and `A_n` it needs in order to update its deposits
 database.
 
 ### Conclusion
@@ -716,8 +743,8 @@ address OP_RETURN output. The address OP_RETURN output MUST be placed right
 after the treasury UTXO output in the M5 transaction's `vout` vector.
 
 If a treasury UTXO for this sidechain slot does not exist, then an M5
-transaction MUST NOT include an input spending the previous treasury UTXO (as
-it doesn't exist).
+transaction MUST NOT include an input spending the previous treasury UTXO (as it
+doesn't exist).
 
 The `nValue` of this phantom non-existent treasury UTXO MUST be set to 0, so
 when a sidechain is first activated in a slot it has exactly 0 sats in
@@ -731,8 +758,8 @@ get the total amount of sats in circulation for the sidechain active in the
 slot.
 
 The `nValue` of the newly created treasury UTXO MUST be greater than the
-`nValue` of the spent treasury UTXO, so when we deposit funds to a sidechain,
-we increase the amount of funds in circulation for that sidechain.
+`nValue` of the spent treasury UTXO, so when we deposit funds to a sidechain, we
+increase the amount of funds in circulation for that sidechain.
 
 ??? QUESTION: What happens to the treasury UTXO when a `used` sidechain slot is
 overwritten with a different sidechain?
@@ -740,17 +767,23 @@ overwritten with a different sidechain?
 Does the same chain of treasury UTXOs continue?
 
 ## Conditions
+
 # M6. "Withdrawal Bundle"
+
 ## Semantics
-An M6 is an aggregate of withdrawals 
+
+An M6 is an aggregate of withdrawals
 
 ```
 [(Bitcoin address, value)]
 ```
 
 Where `S` is the sidechain slot number and `C` is the withdrawals commitment.
+
 ## Definition
+
 ## Encoding
+
 An M6 MUST be a valid Bitcoin transaction.
 
 An M6 MUST have only one input. This one input MUST spend the treasury UTXO for
@@ -774,13 +807,13 @@ public:
 }
 ```
 
-Where `T_n` is the `nValue` for the treasury UTXO created in this M6, `T_n-1`
-is the `nValue` of treasury UTXO spent by this M6, `P_total` is the total
-amount paid out in this withdrawal bundle, and `F_total` is the total amount of
-fees paid to the miners in this withdrawal bundle.
+Where `T_n` is the `nValue` for the treasury UTXO created in this M6, `T_n-1` is
+the `nValue` of treasury UTXO spent by this M6, `P_total` is the total amount
+paid out in this withdrawal bundle, and `F_total` is the total amount of fees
+paid to the miners in this withdrawal bundle.
 
-After the new treasury UTXO at index 0 of the `vout` vector of the M6
-withdrawal bundle transaction come the actual withdrawal pay out outputs.
+After the new treasury UTXO at index 0 of the `vout` vector of the M6 withdrawal
+bundle transaction come the actual withdrawal pay out outputs.
 
 ```C++
 class CTransaction
@@ -797,8 +830,8 @@ class CTransaction
 ```
 
 The amount of funds locked in the newly created treasury UTXO MUST be less than
-the amount of funds locked in the spent treasury UTXO by exactly `P_total +
-F_total`.
+the amount of funds locked in the spent treasury UTXO by exactly
+`P_total + F_total`.
 
 ### The `m6_to_id` function definition
 
@@ -810,9 +843,9 @@ and `T_n-1`, the value locked in the treasury UTXO spent in this `M6`.
 The `m6_to_id` returns either `None` if any of its arguments are invalid or
 `Some(M6ID)`, where `M6ID` is a 32 byte byte array.
 
-We can't use the simple `txid` of the actual `M6` as the `M6ID`, because when
-an `M6` withdrawal bundle is proposed with an `M3`, the treasury UTXO, which
-must be spent by the actual `M6` when its `M6ID` reaches
+We can't use the simple `txid` of the actual `M6` as the `M6ID`, because when an
+`M6` withdrawal bundle is proposed with an `M3`, the treasury UTXO, which must
+be spent by the actual `M6` when its `M6ID` reaches
 `WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD + 1` votes (per `M4` specification) most
 likely does not yet exist.
 
@@ -828,7 +861,6 @@ So we MUST compute the `txid` of something called `M6_blinded`.
    `F_total_be_bytes` is the 64 bit unsigned integer `F_total` (total amount of
    fess paid to the miners by this M6) encoded as an array of 8 bytes in big
    endian order. This `OP_RETURN` output replaces the treasury UTXO.
-
 
 So the `M6ID` is computed in four steps:
 
@@ -846,18 +878,19 @@ In more detail:
    vector, so that the `vin` vector is empty.
 2. Remove the new treasury UTXO from the `vout` vector, it is always the last
    output in the vector.
-2. Compute `P_total` by summing the `nValue`s of all pay out outputs in this
+3. Compute `P_total` by summing the `nValue`s of all pay out outputs in this
    `M6`, so `P_total` = sum of `nValue`s of all outputs of this `M6` except for
    the new treasury UTXO at index 0.
-3. Set `T_n` equal to the `nValue` of the treasury UTXO created in this `M6`.
-4. Compute `F_total = T_n-1 - T_n - P_total`, since we know that `T_n = T_n-1 -
-   P_total - F_total`, `T_n-1` was passed as an argument, and `T_n` and
-   `P_total` were computed in previous steps..
-5. Encode `F_total` as `F_total_be_bytes`, an array of 8 bytes encoding the 64
+4. Set `T_n` equal to the `nValue` of the treasury UTXO created in this `M6`.
+5. Compute `F_total = T_n-1 - T_n - P_total`, since we know that
+   `T_n = T_n-1 - P_total - F_total`, `T_n-1` was passed as an argument, and
+   `T_n` and `P_total` were computed in previous steps..
+6. Encode `F_total` as `F_total_be_bytes`, an array of 8 bytes encoding the 64
    bit unsigned integer in big endian order.
-6. Push an output to the end of `vout` of this `M6` with the `nValue = 0` and
-   `scriptPubKey = OP_RETURN F_total_be_bytes`. So it would replace the
-   treasury UTXO, which was removed previously.
+7. Push an output to the end of `vout` of this `M6` with the `nValue = 0` and
+   `scriptPubKey = OP_RETURN F_total_be_bytes`. So it would replace the treasury
+   UTXO, which was removed previously.
+
 ```C++
 class CTxOut
 {
@@ -867,6 +900,7 @@ public:
 // ...
 }
 ```
+
 At this point we have constructed `M6_blinded`.
 
 7. Compute `M6ID = txid(M6_blinded)`.
@@ -890,7 +924,8 @@ pub struct SidechainProposal {
 }
 ```
 
-and where `ACK` is the `sha256d` hash of the `data` field of `SidechainProposal`.
+and where `ACK` is the `sha256d` hash of the `data` field of
+`SidechainProposal`.
 
 ## Active Sidechains
 
@@ -915,8 +950,8 @@ pub struct Sidechain {
 Where `S` is the sidechain slot number, `n` is the deposit sequence number,
 `block_height` is the Bitcoin block height, `V_n` is the value of the deposit,
 `T_n` is the total amount of funds that was locked in the treasury UTXO before
-`V_n` more was added by this deposit, `A_n` is the deposit destination
-sidechain address.
+`V_n` more was added by this deposit, `A_n` is the deposit destination sidechain
+address.
 
 ## M6IDs
 
@@ -936,11 +971,12 @@ An `M6ID` is _pending_ for sidechain slot `S` while it is present in
 `sidechain_number_to_pending_m6ids[S]`. It is added when proposed by a _valid_
 M3 message (per the M3 specification), and removed when it is either:
 
-* _paid out_ — an `M6` whose `m6_to_id` equals this `M6ID` is included, or
-* _expired_ — its `age` exceeds `WITHDRAWAL_BUNDLE_MAX_AGE`, where `age =
-  current_block_height - proposal_height`.
+- _paid out_ — an `M6` whose `m6_to_id` equals this `M6ID` is included, or
+- _expired_ — its `age` exceeds `WITHDRAWAL_BUNDLE_MAX_AGE`, where
+  `age = current_block_height - proposal_height`.
 
 # Validation Rules specification
+
 ## Transaction Validation Rules specification
 
 These rules only apply to non coinbase transactions.
@@ -948,13 +984,13 @@ These rules only apply to non coinbase transactions.
 A non coinbase transaction is either a regular Bitcoin transaction, an `M5`, or
 an `M6`.
 
-Messages `M1`, `M2`, `M3`, `M4` never appear in non coinbase transactions, if
-an OP_RETURN matching `M1`, or `M2`, `M3`, or `M4` appears in a non coinbase
+Messages `M1`, `M2`, `M3`, `M4` never appear in non coinbase transactions, if an
+OP_RETURN matching `M1`, or `M2`, `M3`, or `M4` appears in a non coinbase
 transaction, then MUST be ignored by the BIP300 enforcer.
 
-If a transaction spends a treasury UTXO as one of its inputs and does not
-create a new treasury UTXO as one of its outputs, that transaction MUST be
-considered invalid.
+If a transaction spends a treasury UTXO as one of its inputs and does not create
+a new treasury UTXO as one of its outputs, that transaction MUST be considered
+invalid.
 
 ### M5
 
@@ -977,15 +1013,15 @@ treasury UTXO, per specification of `M5`.
 ### M6
 
 If a transaction spends a treasury UTXO with value `T_n` as one of its inputs
-and the new treasury UTXO it created has value `T_n+1 < T_n`, then so it MUST
-be considered invalid unless:
+and the new treasury UTXO it created has value `T_n+1 < T_n`, then so it MUST be
+considered invalid unless:
 
 1. It is a valid `M6` according to the `M6` specification above.
 2. Its `M6ID` computed using the `m6_to_id` function, defined above, matches an
    `M6ID` in the BIP300 state that has reached enough votes to be included,
-   meaning that its `vote_count > WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD`
-   and `age <= WITHDRAWAL_BUNDLE_MAX_AGE`, where `age = current_block_height -
-   proposal_block_height`.
+   meaning that its `vote_count > WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD` and
+   `age <= WITHDRAWAL_BUNDLE_MAX_AGE`, where
+   `age = current_block_height - proposal_block_height`.
 
 ## Block Validation Rules specification
 
@@ -1002,6 +1038,7 @@ this block's coinbase transaction and check that the following validation rules
 for `M1`, `M2`, `M3`, `M4` are not violated.
 
 ### M1
+
 A block MUST never be considered invalid because of an `M1`.
 
 There MAY be duplicate `M1`s with exactly the same `S` and `D` in the same
@@ -1014,14 +1051,16 @@ There MAY be multiple `M1`s with different values of `S` and exactly the same
 `D`.
 
 ### M2
-If there are two or more `M2`s upvoting the exact same sidechain proposal `(S,
-ACK)`, then this block MUST be considered invalid.
+
+If there are two or more `M2`s upvoting the exact same sidechain proposal
+`(S, ACK)`, then this block MUST be considered invalid.
 
 /// Maybe it would make more sense to ignore the duplicate upvote? ///
 
 ### M3
-If an `M3` proposes an `M6ID` for sidechain slot `S` that is inactive, then
-this block MUST be considered invalid.
+
+If an `M3` proposes an `M6ID` for sidechain slot `S` that is inactive, then this
+block MUST be considered invalid.
 
 /// Maybe it would make more sense to ignore proposals for inactive slots? ///
 
@@ -1044,6 +1083,7 @@ active sidechain slot for an `M6ID` that doesn't exist, then the block MUST be
 considered invalid.
 
 # BIP300 State update rules
+
 ## Connect Block specification
 
 ### M1
@@ -1065,7 +1105,8 @@ pub struct SidechainProposal {
 - `sidechain_number` MUST be set to `S`.
 - `data` MUST be set to `D`.
 - `vote_count` MUST be set to 0.
-- `proposal_height` MUST be set to the block height of the block in which the `M1` was received.
+- `proposal_height` MUST be set to the block height of the block in which the
+  `M1` was received.
 
 Important:
 
@@ -1078,10 +1119,11 @@ reference implementation.
 
 ### M2
 
-We received an M2 with `S` and `ACK`. Note that `ACK` is equal to the sha256d hash of `D`.
+We received an M2 with `S` and `ACK`. Note that `ACK` is equal to the sha256d
+hash of `D`.
 
-If a sidechain proposal referred to by `ACK` doesn't exist in the database,
-then this M2 MUST be ignored.
+If a sidechain proposal referred to by `ACK` doesn't exist in the database, then
+this M2 MUST be ignored.
 
 We MUST get the sidechain proposal stored at key `ACK` from the database:
 
@@ -1098,15 +1140,16 @@ If the sidechain number `S` doesn't match `sidechain_number` in the proposal we
 got from the database, then this M2 MUST be ignored.
 
 If the two above conditions for ignoring an M2 are not met, then we MUST
-increment the `vote_count` of the proposal and put this updated proposal back
-in the database.
+increment the `vote_count` of the proposal and put this updated proposal back in
+the database.
 
 After the `vote_count` was incremented we MUST check whether or not a new
 sidechain was activated as a result of processing this M2. We do this in the
 following way:
 
-We define `sidechain_proposal_age = height -
-sidechain_proposal.proposal_height`, where `height` is current block height.
+We define
+`sidechain_proposal_age = height - sidechain_proposal.proposal_height`, where
+`height` is current block height.
 
 We set `sidechain_slot_is_used` to `true` if a sidechain exist in the
 `sidechain_number_to_sidechain` database at key `S`, otherwise we set it to
@@ -1147,33 +1190,42 @@ into the `sidechain_number_to_sidechain` database at key `S`.
 
 - `sidechain_number` MUST be set to `S`.
 - `data` MUST be set to `data` of `SidechainProposal` that was activated.
-- `vote_count` MUST be set to current `vote_count` of `SidechainProposal` that was activated.
-- `proposal_height` MUST be set to `proposal_height` of `SidechainProposal` that was activated.
-- `activation_height` MUST be set to the block height of the block in which this `M2` was included.
+- `vote_count` MUST be set to current `vote_count` of `SidechainProposal` that
+  was activated.
+- `proposal_height` MUST be set to `proposal_height` of `SidechainProposal` that
+  was activated.
+- `activation_height` MUST be set to the block height of the block in which this
+  `M2` was included.
 
 So, in summary:
 
 A `SidechainProposal` is promoted from being just a proposal to being an actual
-active `Sidechain`. We do this by removing the promoted `SidechainProposal`
-from the `data_hash_to_sidechain_proposal` database, and by adding the newly
+active `Sidechain`. We do this by removing the promoted `SidechainProposal` from
+the `data_hash_to_sidechain_proposal` database, and by adding the newly
 activated `Sidechain` to the `sidechain_number_to_sidechain` database.
 
 All of this is implemented in the `Bip300::handle_m2_ack_sidechain` method in
 the reference implementation.
 
 ### M3
+
 ### M4
 
 ### M5
+
 ### M6
 
 ## Disconnect Block specification
 
-Whenever a Bitcoin block is disconnected the BIP300 State MUST be updated in
-the following way ... .
+Whenever a Bitcoin block is disconnected the BIP300 State MUST be updated in the
+following way ... .
 
 # Testing Strategy
+
 ## Unit Testing
+
 ## Property Testing
+
 ## Fuzzing
+
 ## Benchmarking

--- a/bip301.md
+++ b/bip301.md
@@ -1,21 +1,23 @@
 BIP-301 Protocol Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in RFC 2119.
 
 # Message headers
+
 ```
 M7: [0xD1, 0x61, 0x73, 0x68]
 M8: [0x00, 0xBF, 0x00]
 ```
 
 # M7. BMM Accept
+
 ## Semantics
 
-When an `M7` with sidechain slot `S` and sidechain block hash `H` is included
-in a mainchain block, it means that the sidechain block with hash `H` is now
-blind merge mined.
+When an `M7` with sidechain slot `S` and sidechain block hash `H` is included in
+a mainchain block, it means that the sidechain block with hash `H` is now blind
+merge mined.
 
 There can be only one `M7` per mainchain block per sidechain slot.
 
@@ -26,11 +28,14 @@ connected by the sidechain nodes.
 
 An `M7` message MUST be encoded as a coinbase output.
 
-A `scriptPubKey` encoding an `M7` BMM Accept message MUST have the following form:
+A `scriptPubKey` encoding an `M7` BMM Accept message MUST have the following
+form:
+
 ```
 OP_RETURN [0xD1, 0x61, 0x73, 0x68] <S> <H>
 ```
-where `S` is the sidechain slot number, and  `H` is the block hash of the
+
+where `S` is the sidechain slot number, and `H` is the block hash of the
 sidechain block to be blind merge mined.
 
 The `nValue` of the coinbase output MUST be ignored.
@@ -39,16 +44,16 @@ The `nValue` of the coinbase output MUST be ignored.
 
 ## Semantics
 
-An `M8` with sidechain block hash `H` is a an offer of a reward to the
-mainchain miners for including an `M7` with the corresponding `S` and `H`.
+An `M8` with sidechain block hash `H` is a an offer of a reward to the mainchain
+miners for including an `M7` with the corresponding `S` and `H`.
 
 Only one `M8` can be accepted per mainchain block per sidechain slot.
 
 A mainchain miner can only get the reward if it includes the corresponding `M7`.
 
 The form the reward would take in the `M8` transaction is not specified here,
-but most likely it would be a regular Bitcoin transaction output paying a sum
-to an address controlled by the miner.
+but most likely it would be a regular Bitcoin transaction output paying a sum to
+an address controlled by the miner.
 
 ## Encoding
 
@@ -61,11 +66,13 @@ When a miner fulfills an `M8` request, it MUST include it in a block along with
 a corresponding `M7` coinbase output.
 
 Output of `M8` at index 0 MUST have a `scriptPubKey` of the following form:
+
 ```
 OP_RETURN [0x00, 0xBF, 0x00] <S> <H> <P>
 ```
-where `S` is the sidechain slot number, `H` is the sidechain block hash, and
-`P` is the previous mainchain block hash.
+
+where `S` is the sidechain slot number, `H` is the sidechain block hash, and `P`
+is the previous mainchain block hash.
 
 The `nValue` of the output of `M8` at index 0 MUST be ignored.
 
@@ -73,8 +80,9 @@ The BIP301 enforcer software MUST not be concerned with any part of the `M8`
 transaction other than the output at index 0 with the `OP_RETURN`.
 
 # Validation Rules
-If a mainchain block contains an `M8` transaction without the corresponding `M7` output,
-then that block MUST be considered invalid.
+
+If a mainchain block contains an `M8` transaction without the corresponding `M7`
+output, then that block MUST be considered invalid.
 
 Corresponding here means that the fields `S` and `H` in `M8` are equal to the
 fields `S` and `H` in `M7`, meaning they both refer to the same sidechain block
@@ -84,8 +92,8 @@ Note that a block MAY contain an `M7` coinbase output without a corresponding
 `M8`, a miner MAY choose to blind merge mine a sidechain block without an
 explicit `M8` request.
 
-If a mainchain block contains an more than one `M7` with the same sidechain
-slot `S`, then that block MUST be considered invalid.
+If a mainchain block contains an more than one `M7` with the same sidechain slot
+`S`, then that block MUST be considered invalid.
 
 If a miner is allowed to accept multiple BMM requests in the same block for the
 same sidechain, then the miner can collect fees for sidechain blocks that were

--- a/justfile
+++ b/justfile
@@ -1,0 +1,2 @@
+fmt:
+    bunx oxfmt@0.58.0 .


### PR DESCRIPTION
Print width was set to 80 to mimic what was already existing, as closely as possible.