### PR TITLE
Clarify M4 behavior

### DIFF
--- a/bip300.md
+++ b/bip300.md
@@ -283,9 +283,19 @@ An M4 can have 4 different version.
 
 `M4 = REPEAT_PREVIOUS_M4 | VOTES_ONE_BYTE | VOTES_TWO_BYTE | UPVOTE_LEADING_BY_50`.
 
-The `REPEAT_PREVIOUS_M4` version of M4 MUST be interpreted as its name suggests
+A coinbase transaction MUST contain at most one M4.
 
-- execute the previously executed M4 again.
+The `REPEAT_PREVIOUS_M4` version of M4 MUST be interpreted as casting the same
+votes that the previous block's M4 resolved to. Repeats chain transitively, and
+repeating an `UPVOTE_LEADING_BY_50` MUST NOT re-evaluate the leading-by-50 rule.
+
+If the previous block has no M4, or its M4 resolved to no votes,
+`REPEAT_PREVIOUS_M4` casts no votes.
+
+A repeated upvote for an `M6ID` that is no longer pending casts no vote in that
+slot. Resolving a `REPEAT_PREVIOUS_M4` MUST NOT render the block invalid.
+
+A repeated alarm downvotes the `M6ID`s pending at the current block.
 
 The `UPVOTE_LEADING_BY_50` version of M4 MUST be interpreted as its name
 suggests. In pseudo code:
@@ -1074,6 +1084,9 @@ There MAY be multiple `M3`s with different values of `S` and exactly the same
 `M6ID`.
 
 ### M4
+
+If a coinbase transaction contains more than one `M4`, then the block MUST be
+considered invalid.
 
 If an `M4` of version `VOTES_ONE_BYTE` or `VOTES_TWO_BYTE` sets a vote in an
 inactive sidechain slots, then the block MUST be considered invalid.


### PR DESCRIPTION
1. Only one M4 is allowed per block
2. REPEAT_PREVIOUS_M4 means the resolved votes of the previous block's M4, and never renders a block invalid. Votes that can no longer be cast are dropped

Closes #7 