### PR TITLE
Disallow duplicate M1 messages

### DIFF
--- a/bip300.md
+++ b/bip300.md
@@ -1039,10 +1039,8 @@ for `M1`, `M2`, `M3`, `M4` are not violated.
 
 ### M1
 
-A block MUST never be considered invalid because of an `M1`.
-
-There MAY be duplicate `M1`s with exactly the same `S` and `D` in the same
-coinbase transaction.
+If a coinbase transaction contains duplicate `M1`s with exactly the same `S` and
+`D`, then the block MUST be considered invalid.
 
 There MAY be multiple `M1`s with exactly the same `S` and different values of
 `D`.


### PR DESCRIPTION
This matches the current behavior of the enforcer. It's fine to be strict with miner-controlled coinbase messages, as this is something the miner has perfect control over.