### PR TITLE
Remove M2 spec internal mismatch, harmonize with enforcer

### DIFF
--- a/bip300.md
+++ b/bip300.md
@@ -193,10 +193,11 @@ conditions hold:
 
 Otherwise, an M2 message is considered _valid_.
 
-If another _valid_ M2 message is included within any coinbase output at a lower
-output index, the block is _invalid_ and MUST be _rejected_. Otherwise, a node
-MUST increment the ACK counter for the sidechain proposal for which the sha256d
-digest is referenced by the `32`-byte proposal identifier.
+If another well-formed M2 message with the same sidechain slot number is
+included within any coinbase output at a lower output index, the block is
+_invalid_ and MUST be _rejected_. Otherwise, a node MUST increment the ACK
+counter for the sidechain proposal for which the sha256d digest is referenced by
+the `32`-byte proposal identifier.
 
 If any of the following conditions hold, activation for the specified sidechain
 proposal _fails_:
@@ -1052,10 +1053,8 @@ There MAY be multiple `M1`s with different values of `S` and exactly the same
 
 ### M2
 
-If there are two or more `M2`s upvoting the exact same sidechain proposal
-`(S, ACK)`, then this block MUST be considered invalid.
-
-/// Maybe it would make more sense to ignore the duplicate upvote? ///
+If a coinbase transaction contains more than one well-formed `M2` with the same
+`S`, then the block MUST be considered invalid, regardless of the `ACK` values.
 
 ### M3
 


### PR DESCRIPTION
The two changed passages in the spec where incompatible with each other. Codify the current enforcer implementation as correct.