### PR TITLE
Add unified BIP-300/301 specifications reconciled against the reference implementation

### DIFF
--- a/ENFORCER_INVALIDATEBLOCK.md
+++ b/ENFORCER_INVALIDATEBLOCK.md
@@ -1,0 +1,247 @@
+# When does the enforcer `invalidateblock`?
+
+A reference for `bip300301_enforcer` — every condition under which a mainchain
+block gets invalidated in bitcoind as a result of BIP300/BIP301 enforcement.
+
+---
+
+## TL;DR
+
+**The enforcer never calls `invalidateblock` itself.** Grep the
+`bip300301_enforcer` tree for the RPC and you will find only comments and
+test-harness setup calls.
+
+The real chain is:
+
+```
+bip300301_enforcer                      cusf-enforcer-mempool                bitcoind
+──────────────────                      ─────────────────────                ────────
+Validator::connect_block()
+  └─ returns ConnectBlockAction::Reject ──► match on Reject
+                                             └─ main_client
+                                                  .invalidate_block(hash) ──► invalidateblock RPC
+```
+
+So "when does the enforcer invalidate a block?" is really **"when does
+`connect_block` return `Reject`?"** — and that has exactly one call site.
+
+---
+
+## The two halves
+
+### 1. The enforcer decides (`bip300301_enforcer`)
+
+| What                                           | Where                                                      |
+| ---------------------------------------------- | ---------------------------------------------------------- |
+| The single `Reject` return                     | `lib/validator/cusf_enforcer.rs:306`                       |
+| Logs `"rejecting block: {reason}"` just before | `lib/validator/cusf_enforcer.rs:304`                       |
+| Reject reasons                                 | `lib/validator/cusf_enforcer.rs:160` (`enum RejectReason`) |
+| Validation errors that feed it                 | `lib/validator/task/error.rs:343` (`enum ConnectBlock`)    |
+
+Note that the header write is **committed** even on reject
+(`header_rwtxn.commit()`), while the block-connect child txn is aborted. The
+enforcer remembers it saw the header; it just refuses to connect the block.
+
+### 2. The driver acts (`cusf-enforcer-mempool`)
+
+Declared in `bip300301_enforcer/Cargo.toml:95` as a git dependency on
+`https://github.com/LayerTwo-Labs/cusf-enforcer-mempool.git`.
+
+| Path                                                               | Where                         |
+| ------------------------------------------------------------------ | ----------------------------- |
+| ZMQ-driven task: `Reject` → `invalidate_block`                     | `lib/cusf_enforcer.rs:318`    |
+| Mempool-sync path: `RequestItem::RejectBlock` → `invalidate_block` | `lib/mempool/sync/mod.rs:498` |
+
+The second is the batched request pipeline; `lib/mempool/sync/mod.rs:70` maps
+that request variant to the literal method name `"invalidateblock"`.
+
+---
+
+## The fatality model
+
+This is the part that decides everything, and it is easy to miss.
+
+Error enums derive `Fatality`/`Split`, and each variant carries a marker:
+
+| Marker              | Meaning                           | Block invalidated?        |
+| ------------------- | --------------------------------- | ------------------------- |
+| `#[fatal(false)]`   | "Jfyi" — the block is bad         | **Yes** → `Reject`        |
+| `#[fatal(true)]`    | Infrastructure failure (DB, disk) | **No** → error propagates |
+| `#[fatal(forward)]` | Inherits from the wrapped error   | Depends                   |
+
+The distinction is deliberate: a corrupted database must never be allowed to
+invalidate honest blocks. Only errors that mean _"this block violates the
+rules"_ reach `RejectReason`.
+
+---
+
+## The complete case list
+
+### Structural (`RejectReason`, `lib/validator/cusf_enforcer.rs:160`)
+
+| Case                  | Condition                                        | Site                   |
+| --------------------- | ------------------------------------------------ | ---------------------- |
+| `MissingParentHeight` | Parent block's height is unknown to the enforcer | `cusf_enforcer.rs:212` |
+| `ConnectBlock(jfyi)`  | Any non-fatal validation error below             | `cusf_enforcer.rs:256` |
+
+### Block-level (`enum ConnectBlock`, `lib/validator/task/error.rs:343`)
+
+| Case                  | Message                                                                       |
+| --------------------- | ----------------------------------------------------------------------------- |
+| `BlockParent`         | ``Block parent `{parent}` does not match tip `{tip}` at height {tip_height}`` |
+| `NoCoinbase`          | `Block has no transactions (missing coinbase)`                                |
+| `MultipleBmmBlocks`   | `Multiple blocks BMM'd in sidechain slot {n}`                                 |
+| `MultipleBmmRequests` | `Multiple BMM requests accepted in sidechain slot {n}`                        |
+| `CoinbaseMessages`    | see below                                                                     |
+
+### Duplicate coinbase messages (`lib/messages.rs:420`)
+
+All four are non-fatal, all four reject:
+
+- `DuplicateM1` — M1 sidechain proposal for a slot already included at an
+  earlier index
+- `DuplicateM2` — M2 acking a proposal for a slot already included
+- `DuplicateM4` — M4 already included
+- `DuplicateM7` — M7 for a slot already included
+
+### M3 — propose bundle (`error.rs:68`)
+
+- `BundleAlreadyPending` — BIP300: an M6ID already proposed and not yet paid out
+  must not be re-proposed; re-proposing would reset its ack count
+- `InactiveSidechain`
+
+### M4 — ack bundles (`error.rs:134`)
+
+- `TwoBytesWithinByteRange` — `M4 TwoBytes encoding with no element > 253` (the
+  encoding wastes a byte per element, so it MUST be rejected)
+- via `HandleM4Votes` (`error.rs:105`): `InvalidVotes` (expected N, found M),
+  `UpvoteFailed`
+
+### M5 / M6 — deposit and withdrawal (`error.rs:215`)
+
+| Case                          | Meaning                                                 |
+| ----------------------------- | ------------------------------------------------------- |
+| `Ambiguous`                   | Cannot be both an M5 deposit and an M6 withdrawal       |
+| `MissingDepositAddress`       | Treasury output not followed by the address `OP_RETURN` |
+| `MultipleOpDrivechainOutputs` | More than one `OP_DRIVECHAIN` output for a sidechain    |
+| `OldCtipUnspent`              | Old Ctip for the sidechain is still unspent             |
+| `TreasurySpentWithoutNewCtip` | Treasury spent without creating a new Ctip              |
+| `ZeroDiff`                    | Cannot deposit or withdraw zero sats                    |
+| `M6id`                        | M6ID mismatch                                           |
+| `InvalidM6`                   | see below                                               |
+
+`InvalidM6` (`error.rs:174`) splits further:
+
+- `InputCount` — M6 withdrawals must have exactly 1 input
+- `InsufficientVoteCount` — vote count below threshold for the bundle
+- `MissingPendingWithdrawal` — M6ID doesn't correspond to a pending withdrawal
+- `TreasuryOutputCount` — must create exactly 1 ctip
+- `TreasuryOutputIndex` — treasury output must be at index 0
+
+### M8 — BMM request (`error.rs:279`)
+
+- `BmmRequestExpired`
+- `NotAcceptedByMiners` — cannot include a BMM request the miners did not accept
+
+---
+
+## What does **not** invalidate
+
+These are the traps. Each looks like it should reject, and doesn't.
+
+**Fatal-only error paths.** `HandleM1ProposeSidechain`, `HandleM2AckSidechain`,
+`HandleFailedM6Ids` and `HandleFailedSidechainProposals` contain _only_
+`#[fatal(true)]` DB variants. An M1 or M2 can never on its own invalidate a
+block — only the duplicate-detection in `CoinbaseMessagesError` can.
+
+**Batch sync.** In `lib/validator/task/mod.rs:1789`, a non-fatal error during
+initial block-batch sync returns `Ok(Some(block_hash))` instead of rejecting.
+The comment is explicit:
+
+> We should not call out to `invalidateblock` in case of failures here, as that
+> is handled by the cusf-enforcer-mempool crate.
+
+**Mempool tx rejection.** `accept_tx` (`lib/validator/cusf_enforcer.rs:445`):
+
+> A fatal error here isn't something that means we should call out to the
+> `invalidateblock` RPC. It simply means the transaction will not be accepted
+> into the mempool.
+
+**Wallet sync on reject.** `lib/wallet/cusf_block_producer.rs:287` deliberately
+skips wallet sync when the validator rejects, because the aborted child txn
+means `get_block_infos` would fail and bubble an error that _prevents_ the
+standalone driver from issuing `invalidateblock`.
+
+---
+
+## Test-harness calls are not enforcer behavior
+
+Several `invalidateblock` hits in the tree are tests _driving_ bitcoind to set
+up a reorg — not the enforcer reacting:
+
+- `bip300301_enforcer/integration_tests/test_zmq_sequence_gap.rs:90`
+- `bip300301_enforcer/integration_tests/test_wallet_reorg_multi_block.rs:146`
+- `cusf-enforcer-mempool/integration_tests/test_disconnect_through_sync_tip.rs:51`
+- `cusf-enforcer-mempool/integration_tests/test_double_insert_after_reorg.rs:40`
+- `cusf-enforcer-mempool/integration_tests/test_enforcer_rejection_during_reorg.rs:49`
+- `cusf-enforcer-mempool/integration_tests/test_reorg_re_inserts_tx.rs:36`
+
+---
+
+## Test coverage
+
+`bip300301_enforcer/integration_tests/block_verdict.rs` defines the harness:
+`Expect::Rejected { log_contains }` asserts the block is invalidated (bitcoind's
+`getblock` reports `confirmations == -1`) _and_ that the log carries the reason.
+
+Cases actually exercised end-to-end in `test_invalid_block.rs`:
+
+| Case               | Expected log                                       |
+| ------------------ | -------------------------------------------------- |
+| Duplicate M1       | `rejecting block: M1 sidechain proposal for slot`  |
+| Duplicate M2       | `rejecting block: M2 that acks proposal for slot`  |
+| Duplicate M4       | `rejecting block: M4 already included at index`    |
+| Duplicate M7       | `rejecting block: M7 for slot`                     |
+| Duplicate M8       | `Multiple BMM requests accepted in sidechain slot` |
+| M5 missing address | `has no address OP_RETURN output`                  |
+
+On the driver side,
+`cusf-enforcer-mempool/integration_tests/test_rejected_block_disconnect.rs`
+asserts the full round trip: a rejected block is invalidated in bitcoind, which
+then emits the disconnect.
+
+Note the duplicate-M7 and duplicate-M8 pair. Both enforce BIP301's _"only one M8
+per mainchain block per sidechain slot"_, but they catch different halves — M7
+is the coinbase commitment, M8 the transaction. The M8 case cannot be caught the
+same way: both requests are individually valid, name the current tip, and carry
+the same h*, so each one legitimately corresponds to the single M7 in the
+coinbase.
+
+---
+
+## Source map
+
+```
+bip300301_enforcer/
+  lib/validator/cusf_enforcer.rs      :160  enum RejectReason
+                                      :212  MissingParentHeight
+                                      :256  RejectReason::ConnectBlock
+                                      :306  ConnectBlockAction::Reject   ← the decision
+                                      :445  why accept_tx does not invalidate
+  lib/validator/task/error.rs         :343  enum ConnectBlock (fatality markers)
+                                      :279  HandleM8
+                                      :215  HandleM5M6
+                                      :174  InvalidM6
+                                      :134  HandleM4AckBundles
+                                      :105  HandleM4Votes
+                                      :68   HandleM3ProposeBundle
+  lib/validator/task/mod.rs           :1789 batch sync does NOT invalidate
+  lib/messages.rs                     :420  CoinbaseMessagesError (duplicate M1/M2/M4/M7)
+  lib/wallet/cusf_block_producer.rs   :287  skip wallet sync on reject
+  Cargo.toml                          :95   cusf-enforcer-mempool git dependency
+
+cusf-enforcer-mempool/
+  lib/cusf_enforcer.rs                :318  invalidate_block on Reject   ← the action
+  lib/mempool/sync/mod.rs             :498  invalidate_block (batched sync path)
+                                      :70   RejectBlock → "invalidateblock"
+```

--- a/NON-INVALIDATING-RESOLUTION.md
+++ b/NON-INVALIDATING-RESOLUTION.md
@@ -110,7 +110,15 @@ changed so the rule is no longer needed_, which is Tier 2.
 
 Thirteen conditions. All satisfy the four conditions above; none requires any
 change to the protocol beyond the resolution rule itself. Four (marked ★) are
-open questions the LayerTwo-Labs draft raises with `???`.
+open questions the LayerTwo-Labs draft raises inline against its own rules:
+three marked `??? QUESTION` (`bip300.md` lines 401, 441, 470, all in M4) and one
+marked `/// ... ///` (line 1070, M3 for an inactive slot).
+
+The draft raises one further `???` that is **not** resolved here — what happens
+to a treasury UTXO when its slot is overwritten (line 773). That is a gap in the
+specification, not a rejection that could be converted, so it falls outside this
+document's scope. It is recorded as item 12 of Appendix A in the unified
+specifications and needs an answer from the authors.
 
 ### 4.1 Duplicate coinbase messages — take the first
 
@@ -237,6 +245,14 @@ anyone implements them.
 
 **Conditions:** `MultipleBmmRequests`, `MultipleBmmBlocks`, `DuplicateM7`,
 `NotAcceptedByMiners`, `BmmRequestExpired`
+
+> **Note on the pending M8 rework.** BMM bidding and accepting are being
+> redesigned, and the M8 _encoding_ described in the specifications descends
+> from a superseded transaction type. None of that touches this section. The
+> argument below turns on **where the M8 payment goes**, not on how the request
+> is encoded — so any re-encoding that keeps the payment on-chain leaves all
+> five conditions exactly where they are. Only §5.1's own remedy, moving the
+> payment off-chain, removes them. See BIP-301 Appendix A, item 7.
 
 #### Why selection fails
 
@@ -478,6 +494,13 @@ them earlier re-opens the fee harvest described in §5.1.
 ---
 
 ## 9. Open questions for reviewers
+
+These five are about **this document's analysis** — whether the proposed
+relaxations are sound. They are not the open questions about what the protocol
+is; those live in [`OPEN-QUESTIONS.md`](./OPEN-QUESTIONS.md), which is the
+agenda to work through with the authors. One of them, the one-proposal-per-block
+limit, would withdraw §4.1's treatment of `DuplicateM1` and the duplicate-M3
+case, so it should be settled before these are reviewed.
 
 1. **Is the harvest analysis in §5.1 complete?** It assumes the miner captures
    M8 fees through ordinary block-fee collection. If some on-chain structure

--- a/NON-INVALIDATING-RESOLUTION.md
+++ b/NON-INVALIDATING-RESOLUTION.md
@@ -1,0 +1,506 @@
+# Non-Invalidating Resolution for BIP-300/301
+
+How far block rejection can be eliminated, what the irreducible floor is, and
+why that floor exists.
+
+Companion to [`ENFORCER_INVALIDATEBLOCK.md`](./ENFORCER_INVALIDATEBLOCK.md),
+which enumerates every condition under which the enforcer currently causes a
+block to be invalidated.
+
+---
+
+## The proposal in one paragraph
+
+Today, a block that violates almost any BIP-300/301 rule is invalidated
+wholesale: the enforcer returns `ConnectBlockAction::Reject` and the driver
+issues `invalidateblock` to bitcoind. For most of these conditions the block is
+perfectly good apart from one ambiguous or redundant message. This document
+sorts every rejection condition into three tiers — **convertible now**,
+**convertible with a design change**, and **irreducible** — and gives the test
+that decides which is which.
+
+**Result: of 29 rejection conditions, 13 can be converted immediately, 6 more
+can be eliminated by two specific design changes, and 9 are irreducible. The
+irreducible 9 are all one rule.**
+
+---
+
+## 1. Why rejection is used at all
+
+Two distinct jobs are being done by the same mechanism, and separating them is
+the whole point of this analysis.
+
+**Job A — preserving consensus.** Every enforcing node must derive the same
+state from the same block. If a block is ambiguous and nodes resolve it
+differently, their databases diverge silently and permanently. Rejecting the
+block is a blunt but certain way to prevent that.
+
+**Job B — making an attack unprofitable.** Some rules exist because a miner
+would otherwise gain by breaking them. Rejection reaches the miner's entire
+block revenue, which is the largest lever available.
+
+Job A does **not** require rejection. It requires _determinism_. If the
+resolution rule is a pure function of `(block, prior state)`, every node
+computes the same answer and consensus holds exactly as well as under rejection.
+
+Job B **does** require rejection, or something equally costly. No amount of
+determinism removes an attacker's profit.
+
+Most convertible cases turn out to be Job A only.
+
+---
+
+## 2. The floor: why zero rejections is impossible
+
+It is worth being blunt about this, because it bounds everything below.
+
+`OP_DRIVECHAIN` is `OP_NOP5 <push S> OP_TRUE`. To a node that does not enforce
+BIP-300, that script evaluates as: no-op, push one byte, push true — it
+**succeeds with an empty scriptSig**. A treasury UTXO is _anyone-can-spend_
+under stock Bitcoin rules. This is not incidental; BIP-300 says so directly, in
+explaining why the trailing `OP_TRUE` is there:
+
+> The final OP_TRUE is to ensure this change remains a softfork.
+
+That is the soft-fork trick, and it has a consequence that is easy to miss:
+**nothing in Bitcoin protects sidechain funds.** The only thing standing between
+a treasury UTXO and anyone with a wallet is that enforcing nodes reject the
+block that spends it improperly.
+
+So the treasury rejection rules are not _enforcement of_ the peg. They **are**
+the peg. Remove them and BIP-300 stops being a soft fork and becomes a
+suggestion — the treasury is spendable by anyone, and the sidechain's entire
+balance is taken in the first block after the rule is dropped.
+
+Every other rejection in the protocol is negotiable. These are not, and no
+resolution rule, however clever, can make them so.
+
+---
+
+## 3. The safety test
+
+A rejection rule `R` may be replaced by a deterministic resolution `D` **only if
+all four conditions hold**:
+
+**(1) Determinism.** `D` is a pure function of the block and the prior state.
+Not arrival order, not mempool contents, not wall-clock, not peer state. In
+practice: tie-breaks must use in-block ordering (output index, transaction
+index) or prior-state ordering (proposal height), never anything observed
+locally.
+
+**(2) Incentive neutrality.** No party's payoff from triggering `D` exceeds
+their payoff from complying.
+
+**(3) Invariant preservation.** `D` cannot leave the state violating a
+fund-safety invariant:
+
+- exactly one treasury UTXO per active slot, at all times;
+- a treasury's value decreases only via an M6 whose `M6ID` cleared the vote
+  threshold;
+- a bundle's vote count changes by at most 1 per block.
+
+**(4) Bounded state.** `D` must not require unbounded memory.
+
+A rule failing any of these keeps its rejection — _unless the protocol itself is
+changed so the rule is no longer needed_, which is Tier 2.
+
+---
+
+## 4. Tier 1 — convertible now
+
+Thirteen conditions. All satisfy the four conditions above; none requires any
+change to the protocol beyond the resolution rule itself. Four (marked ★) are
+open questions the LayerTwo-Labs draft raises with `???`.
+
+### 4.1 Duplicate coinbase messages — take the first
+
+**Conditions:** `DuplicateM1`, `DuplicateM2`, `DuplicateM4`
+
+Process the message at the lowest output index; ignore the rest.
+
+_Determinism:_ output index is fixed by the block. ✔ _Incentives:_ the attacker
+wants more than one message applied — a second ack, a second vote. Taking the
+first caps the effect at exactly what a compliant block achieves. ✔
+
+For `DuplicateM1` the state already works this way: a re-proposal of an existing
+`(slot, description_hash)` is ignored so vote counts cannot be reset. Extending
+that to same-block duplicates is consistent, not novel.
+
+### 4.2 M3 for an inactive slot — ignore ★
+
+**Condition:** `InactiveSidechain`
+
+The original BIP-300 already says: _"M3 is ignored if it does not parse, or if
+it is for a sidechain that doesn't exist."_ The block-invalidity rule
+contradicts the same document's own prose. Proposing a bundle for a dead slot
+accomplishes nothing under either rule. ✔
+
+### 4.3 M3 re-proposing a pending bundle — ignore
+
+**Condition:** `BundleAlreadyPending`
+
+The attack is resetting a bundle's accumulated votes. Ignoring defeats it as
+well as rejecting does, without punishing an honest miner who included a stale
+proposal. ✔
+
+### 4.4 M4 vote array longer than the active-slot vector — truncate ★
+
+**Condition:** `InvalidVotes`
+
+Apply votes at indices mapping to active slots; ignore the excess. The
+active-slot vector is sorted ascending from prior state, so all nodes compute
+the same prefix. The excess entries address slots that do not exist and could
+not move any count under either rule. ✔
+
+### 4.5 M4 bundle index out of range — abstain ★
+
+**Condition:** `UpvoteFailed`
+
+Treat that slot's vote as `ABSTAIN`.
+
+The most elegant of the conversions: `ABSTAIN` is already a first-class vote
+value with defined semantics, so the malformed vote is mapped onto an existing
+transition rather than introducing a new one. Compare the alternative of
+snapping to the nearest valid index, which would be arbitrary and exploitable.
+The miner wanted to upvote a bundle that does not exist; abstain gives them
+nothing, which is the correct payoff. ✔
+
+### 4.6 `VOTES_TWO_BYTE` where one byte suffices — accept ★
+
+**Condition:** `TwoBytesWithinByteRange`
+
+This rule invalidates a block over **encoding efficiency**. A miner loses an
+entire block subsidy for wasting roughly one byte per active sidechain in an
+OP_RETURN they already paid for. The waste is self-penalising; consensus
+enforcement adds nothing. Vote semantics are identical between the two encodings
+by definition. ✔
+
+### 4.7 M5 with no address OP_RETURN — accept as an uncredited deposit
+
+**Condition:** `MissingDepositAddress`
+
+Accept the treasury movement, update the CTIP, credit no depositor.
+
+The subtlest of the group, and it turns on **which direction the error runs**.
+The sats land in the treasury, so the sidechain's L1 backing increases while its
+L2 issuance does not: the result is _over_-collateralisation. No sidechain user
+can lose funds; the depositor loses their own money through their own malformed
+transaction.
+
+Under-collateralisation would fail condition (3) outright.
+Over-collateralisation does not. ✔
+
+Enforcing nodes SHOULD log and expose these so operators can make the depositor
+whole out of band.
+
+### 4.8 Zero-value deposit or withdrawal — accept as a CTIP move
+
+**Condition:** `ZeroDiff`
+
+`T_new == T_old` means no value moved. A no-op costing the sender a fee. ✔
+
+### 4.9 M5/M6 ambiguity — classify by value delta
+
+**Condition:** `Ambiguous`
+
+A transaction cannot both increase and decrease the treasury. Classify strictly:
+`T_new > T_old` → M5, `T_new < T_old` → M6, equality → §4.8. This is a
+clarification rather than a relaxation — once classified, the normal M5 or M6
+rules apply unchanged, and a transaction failing the M6 rules still fails them.
+
+### 4.10 Parent-related conditions — defer rather than reject
+
+**Conditions:** `MissingParentHeight`, `BlockParent`
+
+These are not rule violations at all. They mean _"this node does not yet have
+the context to validate this block"_ — the parent's height is unknown, or the
+block does not build on the current tip.
+
+Invalidating here is actively harmful: a valid block arriving during a reorg, or
+before its parent is processed, gets pushed through `invalidateblock` at
+bitcoind. The correct behaviour is to **defer** — buffer until the parent
+connects, or handle it as normal reorg processing.
+
+This is a bug fix rather than a protocol change, and the only item that improves
+liveness rather than merely reducing disruption.
+
+---
+
+## 5. Tier 2 — convertible with a design change
+
+Six conditions. These cannot be fixed by a resolution rule — each fails test (2)
+— but each becomes **unnecessary** under a specific change to the protocol.
+Unlike Tier 1, these are design proposals and want adversarial review before
+anyone implements them.
+
+### 5.1 The BMM family — eliminated by off-chain requests
+
+**Conditions:** `MultipleBmmRequests`, `MultipleBmmBlocks`, `DuplicateM7`,
+`NotAcceptedByMiners`, `BmmRequestExpired`
+
+#### Why selection fails
+
+Deterministic selection is trivially implementable here: "take the M8 at the
+lowest transaction index", or "take the M8 paying the highest fee", are both
+pure functions of the block. Test (1) passes.
+
+Test (2) fails, for a reason that lies outside BIP-301 entirely.
+
+**An M8 is an ordinary Bitcoin transaction. Its fee is paid to the miner by
+Bitcoin's own consensus rules, regardless of what the enforcer decides about
+it.** The enforcer can decline to _count_ an M8 as a BMM request. It cannot
+decline to let the miner keep the money.
+
+|                                  | Compliant block | Block with 10 M8s for one slot |
+| -------------------------------- | --------------- | ------------------------------ |
+| Side:blocks connected            | 1               | 1                              |
+| BMM fees collected               | 1               | **10**                         |
+| Enforcer verdict under selection | valid           | valid (9 "ignored")            |
+
+The miner is strictly better off breaking the rule, and nine Simons paid for a
+side:block that was never connected. This is the outcome the LayerTwo-Labs draft
+names as the reason for the rule:
+
+> If a miner is allowed to accept multiple BMM requests in the same block for
+> the same sidechain, then the miner can collect fees for sidechain blocks that
+> were not actually connected to the sidechain, which is undesirable.
+
+Rational Simons stop bidding and the BMM market unwinds. The rule is not
+protecting against confusion; it is protecting against theft. Rejection works
+because it is the only response reaching the miner's _entire_ block revenue —
+subsidy, ordinary fees, and harvested BMM fees together.
+
+The same argument covers duplicate M7s (identical harvest, different route) and
+stale M8s (a miner hoarding old requests and mining them later, collecting for
+side:blocks that can no longer connect).
+
+#### The change that eliminates it
+
+**Move BMM payment off-chain.** Under Lightning-based BMM — gestured at in the
+original BIP-301 and specified nowhere — Simon pays Mary conditionally off-chain
+and Mary claims by including the M7. A losing bidder pays **nothing on-chain**.
+
+That single change removes the harvest, and with it the reason for all five
+rejections:
+
+| Condition                           | Why it exists               | Under off-chain requests     |
+| ----------------------------------- | --------------------------- | ---------------------------- |
+| `MultipleBmmRequests`               | miner harvests N fees       | no on-chain fee to harvest   |
+| `MultipleBmmBlocks` / `DuplicateM7` | same harvest via M7         | same                         |
+| `NotAcceptedByMiners`               | M8 fee taken without M7     | payment is conditional on M7 |
+| `BmmRequestExpired`                 | hoarded requests mined late | offer expires off-chain      |
+
+Note what happens to the M7 rules specifically: with no on-chain M8, the "one M7
+per slot" constraint stops being a theft guard and becomes a plain
+well-formedness question — which side:block did the miner endorse? That is Tier
+1 territory: **take the M7 at the lowest output index.**
+
+This is the single highest-leverage change available. It converts five
+rejections at once and is the only path to zero for BIP-301.
+
+**Status: needs a specification.** The mechanism is sketched in the original BIP
+and nowhere formalised. Writing it is a larger piece of work than this document,
+and the five rejections must stay until it exists and is deployed.
+
+### 5.2 Mandatory payout — eliminated by sticky approval
+
+**Condition:** the block in which a bundle crosses the vote threshold MUST
+include the corresponding M6, or the block is invalid.
+
+#### Why it exists
+
+Without it, miners who approved a bundle can simply decline to include the M6
+until the bundle expires at `WITHDRAWAL_BUNDLE_MAX_AGE`, killing an approved
+withdrawal through passive omission at zero cost. There is nothing to "select" —
+the required transaction is absent, so no resolution rule applies.
+
+#### The change that eliminates it
+
+Make approval **sticky** rather than instantaneous:
+
+1. When a bundle's vote count first exceeds
+   `WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD`, it enters an `APPROVED` state.
+2. An `APPROVED` bundle is **exempt from the ordinary expiry clock**. It remains
+   payable indefinitely.
+3. At most one bundle per slot may be `APPROVED` at a time. While a slot has an
+   `APPROVED` bundle, M3 messages for that slot are ignored and ordinary M4
+   votes for that slot cast no votes.
+4. An `APPROVED` bundle leaves that state only by being paid out, or by
+   revocation (below).
+
+Omission then costs miners only time, never the withdrawal. The rejection buys
+nothing and can be dropped: a miner who omits the M6 has merely postponed a
+payment that is still owed.
+
+#### The escape hatch, and why it is needed
+
+Step 2 as stated introduces a worse failure than the one it fixes: a permanently
+`APPROVED` bundle that is never mined would freeze the slot forever — no new
+bundles, no withdrawals, no way out.
+
+So revocation must exist, but it must be **explicit and costly** rather than
+passive:
+
+5. An `APPROVED` bundle is revoked if it accumulates
+   `WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD` cumulative `ALARM` votes while
+   approved. On revocation it is removed and the slot unfreezes.
+
+This preserves what BIP-300 already grants miners — the ability to veto a
+withdrawal — while removing the ability to _silently stall_ one. Killing an
+approved bundle now requires the same sustained, visible, majority-hashrate
+commitment that approving it did. Passive omission achieves nothing.
+
+**Status: design sketch, not a finished rule.** It wants review on at least
+these points: whether alarm-based revocation should use a cumulative or
+consecutive count; whether freezing M3 for a slot creates a griefing vector for
+whoever proposes the approved bundle; and how `REPEAT_PREVIOUS` M4s interact
+with a frozen slot.
+
+---
+
+## 6. Tier 3 — the irreducible treasury lock
+
+**Conditions:** `TreasurySpentWithoutNewCtip`, `MultipleOpDrivechainOutputs`,
+`OldCtipUnspent`, `M6id` mismatch, and the five `InvalidM6` variants
+(`InputCount`, `InsufficientVoteCount`, `MissingPendingWithdrawal`,
+`TreasuryOutputCount`, `TreasuryOutputIndex`).
+
+Nine conditions, but really **one rule**:
+
+> A treasury UTXO may only be spent by an M6 whose `M6ID` cleared the vote
+> threshold, producing exactly one new treasury UTXO for the same slot.
+
+Every condition above is a facet of that single check. Per §2, this rule is the
+peg itself — the treasury is anyone-can-spend to every node that does not
+enforce it.
+
+The individual cases, for completeness:
+
+**`TreasurySpentWithoutNewCtip`** — coins leave the treasury and no new treasury
+is created. There is no "best non-blocking option"; the funds are gone. The most
+important rejection in BIP-300.
+
+**`MultipleOpDrivechainOutputs`, `OldCtipUnspent`** — both produce two live
+treasury UTXOs for one slot. One _could_ deterministically nominate the
+lowest-indexed output as the CTIP, satisfying test (1) — but the other remains a
+spendable `OP_DRIVECHAIN` output for the same slot, permanently breaking _"there
+MUST never be two treasury UTXOs for the same sidechain slot"_. Every subsequent
+deposit and withdrawal becomes ambiguous about which treasury chain it belongs
+to. Determinism is achievable; invariant preservation is not.
+
+**The M6 vote and structure rules** are the authorisation check itself.
+`InsufficientVoteCount` is not a formatting complaint — it _is_ the hashrate
+approval that constitutes the security model.
+
+**`NoCoinbase`** is retained separately as defensive and unreachable: Bitcoin
+rejects a block with no transactions before the enforcer sees it.
+
+---
+
+## 7. Summary
+
+| #   | Condition                             | Today  | Proposed                   | Tier |
+| --- | ------------------------------------- | ------ | -------------------------- | ---- |
+| 1   | `MissingParentHeight`                 | reject | defer                      | 1    |
+| 2   | `BlockParent`                         | reject | defer                      | 1    |
+| 3   | `DuplicateM1`                         | reject | first wins                 | 1    |
+| 4   | `DuplicateM2`                         | reject | first wins                 | 1    |
+| 5   | `DuplicateM4`                         | reject | first wins                 | 1    |
+| 6   | `InactiveSidechain` ★                 | reject | ignore                     | 1    |
+| 7   | `BundleAlreadyPending`                | reject | ignore                     | 1    |
+| 8   | `InvalidVotes` ★                      | reject | truncate                   | 1    |
+| 9   | `UpvoteFailed` ★                      | reject | abstain                    | 1    |
+| 10  | `TwoBytesWithinByteRange` ★           | reject | accept                     | 1    |
+| 11  | `MissingDepositAddress`               | reject | uncredited deposit         | 1    |
+| 12  | `ZeroDiff`                            | reject | CTIP move                  | 1    |
+| 13  | `Ambiguous`                           | reject | classify by delta          | 1    |
+| 14  | `MultipleBmmRequests`                 | reject | off-chain BMM              | 2    |
+| 15  | `MultipleBmmBlocks`                   | reject | off-chain BMM              | 2    |
+| 16  | `DuplicateM7`                         | reject | off-chain BMM → first wins | 2    |
+| 17  | `NotAcceptedByMiners`                 | reject | off-chain BMM              | 2    |
+| 18  | `BmmRequestExpired`                   | reject | off-chain BMM              | 2    |
+| 19  | Mandatory payout                      | reject | sticky approval            | 2    |
+| 20  | `TreasurySpentWithoutNewCtip`         | reject | **keep**                   | 3    |
+| 21  | `MultipleOpDrivechainOutputs`         | reject | **keep**                   | 3    |
+| 22  | `OldCtipUnspent`                      | reject | **keep**                   | 3    |
+| 23  | `M6id` mismatch                       | reject | **keep**                   | 3    |
+| 24  | `InvalidM6::InputCount`               | reject | **keep**                   | 3    |
+| 25  | `InvalidM6::InsufficientVoteCount`    | reject | **keep**                   | 3    |
+| 26  | `InvalidM6::MissingPendingWithdrawal` | reject | **keep**                   | 3    |
+| 27  | `InvalidM6::TreasuryOutputCount`      | reject | **keep**                   | 3    |
+| 28  | `InvalidM6::TreasuryOutputIndex`      | reject | **keep**                   | 3    |
+| 29  | `NoCoinbase`                          | reject | keep (unreachable)         | —    |
+
+```
+29 conditions today
+ -13  Tier 1, resolution rules only            → 16
+ - 5  Tier 2, off-chain BMM specification      → 11
+ - 1  Tier 2, sticky approval                  → 10
+ = 9 treasury conditions + NoCoinbase
+```
+
+**The floor is the treasury lock: one rule, nine facets.**
+
+---
+
+## 8. Deployment: this is not a soft fork
+
+**The most important caveat in this document.**
+
+Every change above **relaxes** validity. A node running the new rules accepts
+blocks a node running the old rules rejects. Between two enforcer versions that
+is not a soft fork — it is a **chain split**, because under BIP-300 the enforcer
+drives bitcoind's `invalidateblock`. Old-version nodes follow one chain and
+new-version nodes another, on any block exercising a converted rule.
+
+(Relative to Bitcoin itself nothing changes: non-enforcing nodes already accept
+all these blocks. The split is confined to the enforcer network — precisely the
+set of nodes whose agreement BIP-300 depends on.)
+
+Two viable paths:
+
+1. **Ship before mainnet activation.** BIP-300 is not activated. Until it is,
+   changing these rules costs nothing but a coordinated release. Overwhelmingly
+   the cheaper path, and the reason to settle this now.
+
+2. **Flag-day activation.** After activation, changes must land at an agreed
+   height with every enforcing node upgraded beforehand. Standard, but expensive
+   and slow.
+
+What must **not** happen is incremental rollout. A node converting these rules
+unilaterally forks itself off the enforcer network the first time a miner emits
+a duplicate M2.
+
+Tier 2 carries an additional ordering constraint: the five BMM rejections cannot
+be dropped until off-chain BMM is specified, implemented, and in use. Dropping
+them earlier re-opens the fee harvest described in §5.1.
+
+---
+
+## 9. Open questions for reviewers
+
+1. **Is the harvest analysis in §5.1 complete?** It assumes the miner captures
+   M8 fees through ordinary block-fee collection. If some on-chain structure
+   could make a losing bidder pay nothing, the BMM cases would become Tier 1
+   without needing Lightning. No such structure is obvious under current script
+   rules, but the question is worth putting to reviewers who know covenant
+   proposals well.
+
+2. **Does sticky approval (§5.2) create a griefing vector?** Freezing M3 for a
+   slot while a bundle is approved means whoever gets a bundle approved can
+   block all other withdrawal proposals for that slot until it is paid or
+   revoked. Is the revocation threshold low enough to bound that?
+
+3. **Should `MissingDepositAddress` credit a canonical address instead?** §4.7
+   credits nobody. An alternative is a per-sidechain "unattributed deposits"
+   address, which is friendlier to depositors but adds a field to the sidechain
+   description that this proposal otherwise treats as opaque.
+
+4. **Does deferring on `BlockParent` (§4.10) race with the driver's reorg
+   handling?** The driver already handles disconnects; deferral must not
+   conflict. Needs review against
+   `cusf-enforcer-mempool/lib/mempool/sync/task.rs`.
+
+5. **Is `NoCoinbase` truly unreachable?** Worth confirming there is no path —
+   e.g. a malformed block delivered over ZMQ — by which the enforcer could
+   observe a block with no transactions.

--- a/OPEN-QUESTIONS.md
+++ b/OPEN-QUESTIONS.md
@@ -7,15 +7,38 @@ something.
 The order is not arbitrary — see [Why this order](#why-this-order). Work down
 it.
 
-| #   | Question                                  | Where               | Blocks                              | Answerable         |
-| --- | ----------------------------------------- | ------------------- | ----------------------------------- | ------------------ |
-| 1   | Treasury UTXO when a slot is overwritten  | BIP-300 A12         | Fund safety; possibly a new rule    | Now, by discussion |
-| 2   | Which NOP opcode `OP_DRIVECHAIN` uses     | BIP-300 A13         | Every treasury `scriptPubKey`       | Now, one word      |
-| 3   | M2 header byte — `BF` or `DF`             | BIP-300 A1          | Byte-level correctness; publication | Now, one word      |
-| 4   | One M1 / M3 per block                     | BIP-300 A9          | Enforcer change; extended B1 + B10  | Now, by discussion |
-| 5   | The 90% unused-slot threshold             | BIP-300 A3          | Nothing — confirm or correct        | Now, by discussion |
-| 6   | What the M8 rework must preserve          | BIP-301 A7 (A3, A5) | The BIP-301 M8 section              | Now, partially     |
-| 7   | Five questions on the relaxation analysis | NON-INVALIDATING §9 | Only the extended variant           | Later              |
+Items 1–7 came from reconciling the three documents against each other. Items
+8–12 came from something else: **an independent implementation of BIP-300/301,
+written from these specifications, in Bitcoin Core.** Building it surfaced five
+more places where the specification and the reference implementation say
+different things, and one of them — item 8 — decides what the peg actually
+guarantees.
+
+Those five are not opinions about the Rust. The implementation is checked
+against the reference implementation by 46 generated vectors covering the
+message formats and `M6ID`, and agrees with it on all of them; where this
+document says "the implementation does X", that is a behaviour two
+implementations now agree on. A further list of **corrections needing no
+decision** follows the questions.
+
+| #   | Question                                       | Where               | Blocks                              | Answerable         |
+| --- | ---------------------------------------------- | ------------------- | ----------------------------------- | ------------------ |
+| 1   | Treasury UTXO when a slot is overwritten       | BIP-300 A12         | Fund safety; possibly a new rule    | Now, by discussion |
+| 2   | Which NOP opcode `OP_DRIVECHAIN` uses          | BIP-300 A13         | Every treasury `scriptPubKey`       | Now, one word      |
+| 3   | M2 header byte — `BF` or `DF`                  | BIP-300 A1          | Byte-level correctness; publication | Now, one word      |
+| 4   | One M1 / M3 per block                          | BIP-300 A9          | Enforcer change; extended B1 + B10  | Now, by discussion |
+| 5   | The 90% unused-slot threshold                  | BIP-300 A3          | Nothing — confirm or correct        | Now, by discussion |
+| 6   | What the M8 rework must preserve               | BIP-301 A7 (A3, A5) | The BIP-301 M8 section              | Now, partially     |
+| 7   | Five questions on the relaxation analysis      | NON-INVALIDATING §9 | Only the extended variant           | Later              |
+| 8   | Is Mandatory payout a real rule?               | BIP-300 M4          | What an approved withdrawal means   | Now, by discussion |
+| 9   | Must an M4 vote array match exactly?           | BIP-300 M4          | Block validity; enforcer or spec    | Now, one word      |
+| 10  | Do proposals fail early when they cannot win?  | BIP-300 M2          | When an ack is ignored              | Now, by discussion |
+| 11  | Must a blinded M6 pay out something?           | BIP-300 M6          | Enforcer change, or drop the rule   | Now, one word      |
+| 12  | Does an M7 for an inactive slot mean anything? | BIP-301             | Nothing much — confirm or correct   | Now, one word      |
+
+**Item 8 belongs beside item 1 by this document's own ordering rule** — it is
+the second question here whose answer changes what happens to money. It sits at
+8 only to keep the numbering of a list that is already under review stable.
 
 ---
 
@@ -163,6 +186,166 @@ necessarily an original author.
 
 ---
 
+# Found by implementing it
+
+The five below were not visible from the documents. They surfaced while writing
+a second implementation from these specifications and comparing it, rule by
+rule, against the reference implementation.
+
+## 8. Is "Mandatory payout" a real rule?
+
+**BIP-300, M4, "Mandatory payout". The largest gap between the specification and
+the implementation.**
+
+The specification says that when a bundle's vote count exceeds
+`WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD`, the block in which that happens MUST
+include the corresponding M6, and that a block which does not is **invalid**.
+
+**The enforcer has no such check.** The threshold appears in validation in
+exactly one place — `handle_m6` (`lib/validator/task/mod.rs:663`), where it
+gates whether an M6 that _has been submitted_ is acceptable — and once more in
+`lib/block_producer/coinbase.rs:388`, where the block producer decides whether
+to _build_ one. Nothing anywhere rejects a block for omitting a payout that has
+been approved.
+
+The difference is what the peg guarantees. Under the specification, crossing the
+threshold compels payment in that very block. Under the implementation, crossing
+it makes the bundle _payable_ — and miners who approve a withdrawal and then
+never include it strand it until it expires at 26300 blocks, at which point it
+pays nothing and must be proposed again from zero. Both are defensible designs.
+They are not the same promise to a sidechain's users.
+
+Note also that the specification's version is demanding: the block that crosses
+the threshold is the block carrying the M4 that crosses it, so a miner voting a
+bundle over the line must have the M6 constructed and included in the same
+block. That is buildable — the block producer already assembles M6s — but it is
+a real obligation on whoever mines that block, and it should be intended rather
+than inherited.
+
+**The ask:** is the Mandatory payout section a rule or aspiration? If a rule,
+the enforcer needs the check and the specification stands as written. If not,
+the section should be struck and the guarantee restated: an approved withdrawal
+is payable, not compelled.
+
+## 9. Must an M4 vote array match the active-slot count exactly?
+
+**BIP-300, M4, Validation.**
+
+The specification invalidates a block whose vote array `A` has **more** elements
+than the active-slot vector `ASN`. The implementation requires the two to be
+**equal** — `handle_m4_votes` (`lib/validator/task/mod.rs:379`) rejects on
+`upvotes.len() != active_sidechains.len()`, so a _short_ array is invalid too.
+
+A miner who votes on fewer slots than are active has a block that the
+implementation rejects and the specification accepts. That is not hypothetical
+once slots are being claimed: the active set grows, and an array built against a
+stale view of it is short rather than long.
+
+**The ask:** which is right? The implementation's rule is the more defensible —
+a short array leaves the trailing slots with no defined vote, where the
+specification's own abstain sentinel exists precisely to say "no vote" — but the
+specification says something else and one of them has to move.
+
+## 10. Do proposals fail early when they can no longer win?
+
+**BIP-300, M2, Activation.**
+
+The specification discards a proposal when its age exceeds the relevant
+`MAX_AGE`. The implementation also discards it once it has missed enough blocks
+that it can no longer reach the threshold inside the window that remains
+(`handle_failed_sidechain_proposals`, `lib/validator/task/mod.rs:324`):
+
+```
+max_fails = max_age - threshold
+fails     = age - vote_count
+failed    = age > max_age || (age > max_fails && fails >= max_fails)
+```
+
+For an empty mainnet slot that is 201 missed blocks out of 2016. A proposal with
+100 acks at block 301 is already gone under the implementation and still alive
+under the specification for another 1715 blocks.
+
+This is consensus-visible, not a tidiness optimisation. The proposal leaves D1
+earlier, so a later M2 naming it is ignored rather than counted, and the same
+`(S, proposal_id)` becomes proposable afresh sooner.
+
+**The ask:** intended? If yes it is new specification text. If no it is an
+enforcer change.
+
+## 11. Must a blinded M6 pay out something?
+
+**BIP-300, M6, "M6ID and the blinded form".**
+
+The specification says the blinded form MUST have a non-zero total payout.
+`compute_m6id` (`lib/messages.rs`) never looks at `P_total`, and nothing
+downstream does either.
+
+So a withdrawal that pays out nothing and hands the entire difference to the
+miner as fee is accepted, provided the bundle was approved. It is not obviously
+exploitable — the bundle still has to be voted through — but it is a stated MUST
+that no implementation enforces, and it burns sidechain funds to a miner rather
+than paying anyone on L1.
+
+**The ask:** keep the rule and enforce it, or drop it from the specification?
+
+## 12. Does an M7 for an inactive slot mean anything?
+
+**BIP-301, "Interaction with BIP-300".**
+
+The specification says messages naming an inactive slot have no BMM meaning. The
+implementation records an M7's commitment without checking whether the slot
+holds a sidechain (`lib/validator/task/mod.rs:953`), so an M8 naming an inactive
+slot is accepted as long as the matching M7 is in the coinbase.
+
+Nothing much turns on it — blind merge mining a sidechain that does not exist
+buys nobody anything — but it is the difference between a sentence about
+semantics and a validity rule, and an implementer has to know which it is.
+
+**The ask:** is "no BMM meaning" descriptive, or a rule that M7 and M8 for an
+inactive slot are ignored?
+
+---
+
+# Corrections needing no decision
+
+These are places where the documents are simply wrong or silent, and the
+implementation is right. They are listed for a reviewer's confidence rather than
+for a decision.
+
+**Treasury outputs on inactive slots are ordinary outputs.** The specification
+defines a treasury UTXO purely by its `scriptPubKey`. The implementation
+additionally requires the slot to hold an active sidechain and skips the output
+otherwise (`lib/validator/task/mod.rs:715`). The guard is load-bearing: without
+it a zero-value `OP_DRIVECHAIN` output naming a slot with no sidechain reads as
+a treasury moving to zero, and a perfectly good block is rejected. The
+specification needs the sentence.
+
+**The message byte counts are stated for the wrong encoding.** BIP-300 gives M2
+and M3 as "exactly 38 bytes" and M4 versions 0 and 3 as "exactly 6 bytes",
+counting the tag as raw script bytes. Every message is in fact
+`OP_RETURN <push>` with the tag at the start of the pushed data
+(`CoinbaseMessage::parse`, `lib/messages.rs:307`), so those scripts are 39 and 7
+bytes. BIP-301 already describes the encoding correctly for M7; BIP-300 does not
+for the rest.
+
+**Per-network parameters are undocumented.** The specification says non-mainnet
+networks MAY substitute shorter values. The implementation carries three named
+sets — mainnet, a tiny one for regtest, and a middle one for dry-run networks
+(`lib/types.rs`) — and an activation height below which blocks are recorded but
+never scanned for messages or deposits. Both are consensus-relevant per network
+and neither appears in the documents.
+
+**The duplicate-M3 rule is enforced indirectly.** The specification invalidates
+a block whose coinbase carries two M3s with the same `(S, M6ID)`. The
+implementation has no such check when reading coinbase messages —
+`CoinbaseMessages::push` carries `// TODO: ensure that M3 pushes are valid`
+(`lib/messages.rs:496`) — but the outcome is the same, because the first M3
+makes the bundle pending and the second then breaks the already-pending rule.
+The independent implementation reproduces this and has a test asserting the
+equivalence. No change is needed; the TODO should not be read as a gap.
+
+---
+
 ## Why this order
 
 Three rules produced it.
@@ -183,3 +366,10 @@ in a meeting, only scoped in one.
 
 Item 5 sits low not because it is unimportant but because nothing depends on it:
 whichever way it goes, no other item's answer changes.
+
+**Items 8–12 are numbered after 7 and ranked before it.** By the rules above,
+item 8 belongs beside item 1: it is a money question, and the only other one on
+the list. Items 9 and 11 are one-word answers whose cost curve is the same as
+items 2 and 3 — cheap now, expensive after anything is deployed against them.
+Item 10 needs discussion; item 12 needs a sentence. They keep their numbers only
+so that a list already under review does not renumber underneath its reviewers.

--- a/OPEN-QUESTIONS.md
+++ b/OPEN-QUESTIONS.md
@@ -1,0 +1,185 @@
+# Open questions for the authors
+
+Everything in this repository is settled except the items below. This is the
+agenda: each one is a decision only the authors can make, and each is blocking
+something.
+
+The order is not arbitrary — see [Why this order](#why-this-order). Work down
+it.
+
+| #   | Question                                  | Where               | Blocks                              | Answerable         |
+| --- | ----------------------------------------- | ------------------- | ----------------------------------- | ------------------ |
+| 1   | Treasury UTXO when a slot is overwritten  | BIP-300 A12         | Fund safety; possibly a new rule    | Now, by discussion |
+| 2   | Which NOP opcode `OP_DRIVECHAIN` uses     | BIP-300 A13         | Every treasury `scriptPubKey`       | Now, one word      |
+| 3   | M2 header byte — `BF` or `DF`             | BIP-300 A1          | Byte-level correctness; publication | Now, one word      |
+| 4   | One M1 / M3 per block                     | BIP-300 A9          | Enforcer change; extended B1 + B10  | Now, by discussion |
+| 5   | The 90% unused-slot threshold             | BIP-300 A3          | Nothing — confirm or correct        | Now, by discussion |
+| 6   | What the M8 rework must preserve          | BIP-301 A7 (A3, A5) | The BIP-301 M8 section              | Now, partially     |
+| 7   | Five questions on the relaxation analysis | NON-INVALIDATING §9 | Only the extended variant           | Later              |
+
+---
+
+## 1. What happens to a treasury UTXO when its slot is overwritten?
+
+**BIP-300 Appendix A, item 12. UNRESOLVED.**
+
+`bip300.md:773` asks this and nothing answers it — not the original draft, not
+the LayerTwo-Labs draft, not the unified documents, not the companion proposal.
+
+Read literally, the rules give only one answer. A treasury UTXO is identified
+solely by the slot number in its `scriptPubKey`; a slot has at most one; an M1
+overwrite changes the slot's description without touching the UTXO set. So the
+same chain of treasury UTXOs continues and **the incoming sidechain inherits the
+outgoing sidechain's balance** — which the outgoing sidechain's users can no
+longer withdraw, because their pending bundles name a sidechain the slot no
+longer describes.
+
+Note the bar: overwriting a _used_ slot needs
+`USED_SIDECHAIN_SLOT_ACTIVATION_THRESHOLD`, a bare majority sustained over 26300
+blocks. The 90% bar of item 5 below guards _empty_ slots only.
+
+**The ask:** is inheritance intended? If not, the spec needs a rule for what
+happens to the funds — and that rule is new text in M1 and M5, plus enforcer
+work. This is first on the list because it is the only open item that can change
+where money goes.
+
+## 2. Which NOP does `OP_DRIVECHAIN` use?
+
+**BIP-300 Appendix A, item 13. OPEN DECISION.**
+
+All three sources use `OP_NOP5` (`0xB4`). The proposal on the table is to move
+to `OP_NOP8` (`0xB7`) or `OP_NOP9` (`0xB8`), because the choice is arbitrary and
+`OP_NOP4`–`OP_NOP7` are the numbers a future Bitcoin Core soft fork is most
+likely to reach for first.
+
+Cost of moving today: near zero — nothing is deployed on mainnet, so no treasury
+`scriptPubKey` exists that would have to change. Cost of moving later: every
+treasury UTXO, the enforcer, and every sidechain implementation.
+
+**The ask:** pick one number. Two candidates have been named and only one can be
+used. This is second because it is the cheapest decision on the list and the
+most expensive to defer.
+
+## 3. Is the M2 header byte `BF` or `DF`?
+
+**BIP-300 Appendix A, item 1. UNRESOLVED.**
+
+| Source                   | Value         |
+| ------------------------ | ------------- |
+| Original BIP-300         | `D6 E1 C5 BF` |
+| LayerTwo-Labs draft      | `D6 E1 C5 BF` |
+| Reference implementation | `D6 E1 C5 DF` |
+
+The implementation disagrees with both specifications in the final byte. The
+unified documents follow the implementation, since that is what interoperating
+software must match today, but one side has a bug and the documents cannot tell
+which. If the specs are right, the enforcer has a wire-format bug. If the
+enforcer is right, both specs do.
+
+**The ask:** a one-word answer from whoever wrote the parser or the original
+tag. Nothing byte-exact can be published until it is given.
+
+## 4. Restore the one-proposal-per-block limit?
+
+**BIP-300 Appendix A, item 9. OPEN DECISION.**
+
+The original draft allowed one M1 per block, and one M3 per slot per block. The
+enforcer rejects only exact duplicates — same `(S, proposal_id)` for M1, same
+`(S, M6ID)` for M3 — so differing content in the same slot is permitted, and the
+rate limit is gone.
+
+The narrowing was not a deliberate policy change. The original rule was a rate
+limit with two purposes: stopping a miner from filling a coinbase with proposals
+to grief the slot table or crowd out someone else's, and keeping the demand on
+miner attention small, which was part of what made BIP-300 acceptable to miners
+at all. Neither purpose is served by the current rule.
+
+Both purposes have since been restated by the authors as deliberate, and the
+rapid activation of seven sidechains during testing was possible only because
+the limit is absent.
+
+**The ask:** restore it or close it. Restoring means **the enforcer changes, not
+the documents** — this is the one item where the specification would lead the
+implementation rather than describe it. It also withdraws items 1 and 10 of the
+extended variant's Appendix B, so it must be settled before that variant is
+reviewed.
+
+## 5. Is the 90% unused-slot threshold intended?
+
+**BIP-300 Appendix A, item 3. Not formally open — flagged for confirmation.**
+
+The original draft set 1008 fails out of 2016 blocks: a **50%** bar for claiming
+an empty slot. The LayerTwo-Labs draft and the implementation set 1815 out of
+2016: a **90%** bar. The unified documents follow the implementation.
+
+This is a substantive policy difference, not an editorial one — it moves
+claiming an empty slot from a bare majority of hashrate to a supermajority.
+
+**The ask:** confirm it was deliberate, or correct it. Lower stakes than the
+items above, but it should not go to publication unexamined.
+
+## 6. What must the M8 rework preserve?
+
+**BIP-301 Appendix A, item 7, with items 3 and 5. OPEN.**
+
+BMM bidding and accepting are a work in progress. The M8 encoding in both prior
+drafts — and still in the deployed enforcer — descends from a superseded design
+in which a BMM request was a distinct transaction type carrying a critical-data
+field, not an ordinary transaction with an `OP_RETURN`.
+
+This one cannot be closed by discussion; it closes when the new mechanism
+exists. What **can** be settled now is the contract the rework has to hit:
+
+| Must survive any redesign                                                      | May change freely                                       |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------- |
+| An M8 is valid only with a matching M7 in the same block (same `S`, `H`)       | Whether the request is in an output, and at what index  |
+| At most one M8 per slot per mainchain block                                    | Tag bytes, their length, the push encoding              |
+| An M8 binds to exactly one parent block, so requests cannot be hoarded         | Whether binding is a `P` field, an `nLockTime`, or else |
+| Nothing else in the transaction is interpreted; payment stays out of consensus | Whether the request is on-chain at all                  |
+
+**The ask:** confirm the left column is complete and correct. It is the whole of
+BIP-301's consensus content, and it is what a reviewer of the new mechanism
+should check against.
+
+**A loose end while you're there:** the wallet sets an `nLockTime` on M8
+transactions and the RPC takes a `height`, but no validation rule reads either.
+Both are residue of the old design, where the transaction carried the request's
+expiry; `P` does that now. If the rework keeps `nLockTime`, it should be
+specified; if not, it should come out of the wallet. Right now it is an
+undocumented field that looks meaningful and is not.
+
+## 7. The relaxation analysis
+
+**`NON-INVALIDATING-RESOLUTION.md` §9. Five questions.**
+
+These are a different conversation: they ask whether the _proposed relaxations_
+are sound, not what the protocol is. They only matter if the extended variant is
+pursued, and item 4 above should be settled first, since it withdraws two of the
+resolutions they discuss.
+
+Left where they are rather than merged into this list, because the audience is
+different — a reviewer who knows covenant proposals and reorg handling, not
+necessarily an original author.
+
+---
+
+## Why this order
+
+Three rules produced it.
+
+**Money before mechanism.** Item 1 is the only question whose answer can move
+funds between parties. Everything else is a wire format or a policy knob. It
+goes first even though it is the least likely to have a quick answer.
+
+**Cheap-now, expensive-later before cheap-always.** Items 2 and 3 are each a
+one-word answer, but their cost curve is steep: an opcode collision or a wrong
+tag byte is trivial to fix today and very expensive after deployment. They sit
+above items that will cost the same to decide next month as they do now.
+
+**Decisions before reviews.** Item 4 changes what the extended variant says, so
+it precedes item 7, which reviews it. Item 6 is last of the substantive items
+because it tracks an implementation rather than a decision — it cannot be closed
+in a meeting, only scoped in one.
+
+Item 5 sits low not because it is unimportant but because nothing depends on it:
+whichever way it goes, no other item's answer changes.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# BIP-300 / BIP-301 specifications
+
+Working specifications for **Hashrate Escrows** (BIP-300) and **Blind Merged
+Mining** (BIP-301), reconciled against the reference implementation
+[`bip300301_enforcer`](https://github.com/LayerTwo-Labs/bip300301_enforcer).
+
+Three sources exist for these protocols and they do not agree with each other:
+the original BIP drafts, the LayerTwo-Labs protocol specifications in this
+repository, and the enforcer's actual behaviour. The unified documents below
+merge all three, resolve every disagreement in favour of the implementation, and
+record the evidence for each resolution so the merge can be audited rather than
+trusted.
+
+## What to read
+
+Start with the **baseline** documents. They describe the protocol as it is
+enforced today and propose no behavioural change.
+
+| Document                                                 | Contents                                                          |
+| -------------------------------------------------------- | ----------------------------------------------------------------- |
+| [`bip300-unified.mediawiki`](./bip300-unified.mediawiki) | BIP-300, unified. Appendix A records 11 reconciled disagreements. |
+| [`bip301-unified.mediawiki`](./bip301-unified.mediawiki) | BIP-301, unified. Appendix A records 6 reconciled disagreements.  |
+
+The **extended** documents are the same reconciliation plus an Appendix B that
+replaces block rejections with deterministic resolution. They **do** change
+behaviour and should be read as a delta against the baseline.
+
+| Document                                                                   | Contents                                                                                                   |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| [`bip300-unified-extended.mediawiki`](./bip300-unified-extended.mediawiki) | Baseline + Appendix B: 11 conditions resolved deterministically instead of rejecting the block.            |
+| [`bip301-unified-extended.mediawiki`](./bip301-unified-extended.mediawiki) | Baseline + Appendix B: why BIP-301's rejections are _not_ convertible, and how off-chain BMM removes them. |
+
+Every change in an extended Appendix B **relaxes** validity: a node running
+those rules accepts blocks a node running the baseline rules rejects. Between
+enforcer versions that is a chain-splitting change, not a soft fork, and it
+requires coordinated activation.
+
+## Analysis
+
+| Document                                                             | Contents                                                                                                                                                              |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`ENFORCER_INVALIDATEBLOCK.md`](./ENFORCER_INVALIDATEBLOCK.md)       | Every condition under which the enforcer causes a mainchain block to be invalidated, and the call chain that gets it there.                                           |
+| [`NON-INVALIDATING-RESOLUTION.md`](./NON-INVALIDATING-RESOLUTION.md) | Sorts all 29 rejection conditions into convertible now (13), convertible with a design change (6), and irreducible (9). Source of the extended documents' Appendix B. |
+
+## Prior specifications
+
+[`bip300.md`](./bip300.md) and [`bip301.md`](./bip301.md) are the LayerTwo-Labs
+specifications that predate the unification. They are kept for reference and as
+one of the three inputs to it; the unified documents supersede them.
+
+## Open questions
+
+- **The M2 header byte is unresolved.** Both the original BIP-300 and
+  `bip300.md` give `D6 E1 C5 BF`; the implementation uses `D6 E1 C5 DF`. Nothing
+  in any source reveals which is correct. The unified documents follow the
+  implementation and mark this UNRESOLVED — see Appendix A, item 1. It needs
+  author input.
+
+## Development
+
+Markdown, JSON and YAML are formatted with
+[oxfmt](https://github.com/oxc-project/oxc) (80 columns, prose wrapped). CI
+rejects any diff.
+
+```
+just fmt
+```
+
+`just fmt` calls `bunx`, so it requires [bun](https://bun.sh).
+`npx oxfmt@0.58.0 .` is equivalent when bun is unavailable. The `.mediawiki`
+files are not touched by the formatter.

--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ Mining** (BIP-301), reconciled against the reference implementation
 Three sources exist for these protocols and they do not agree with each other:
 the original BIP drafts, the LayerTwo-Labs protocol specifications in this
 repository, and the enforcer's actual behaviour. The unified documents below
-merge all three, resolve every disagreement in favour of the implementation, and
-record the evidence for each resolution so the merge can be audited rather than
-trusted.
+merge all three, resolve each disagreement in favour of the implementation — or
+mark it open, where the resolution is an author's call rather than an editor's —
+and record the evidence so the merge can be audited rather than trusted.
 
 ## What to read
 
 Start with the **baseline** documents. They describe the protocol as it is
 enforced today and propose no behavioural change.
 
-| Document                                                 | Contents                                                          |
-| -------------------------------------------------------- | ----------------------------------------------------------------- |
-| [`bip300-unified.mediawiki`](./bip300-unified.mediawiki) | BIP-300, unified. Appendix A records 11 reconciled disagreements. |
-| [`bip301-unified.mediawiki`](./bip301-unified.mediawiki) | BIP-301, unified. Appendix A records 6 reconciled disagreements.  |
+| Document                                                 | Contents                                                             |
+| -------------------------------------------------------- | -------------------------------------------------------------------- |
+| [`bip300-unified.mediawiki`](./bip300-unified.mediawiki) | BIP-300, unified. Appendix A records 13 items, 4 of them still open. |
+| [`bip301-unified.mediawiki`](./bip301-unified.mediawiki) | BIP-301, unified. Appendix A records 7 items, 2 of them still open.  |
 
 The **extended** documents are the same reconciliation plus an Appendix B that
 replaces block rejections with deterministic resolution. They **do** change
@@ -41,6 +41,7 @@ requires coordinated activation.
 | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`ENFORCER_INVALIDATEBLOCK.md`](./ENFORCER_INVALIDATEBLOCK.md)       | Every condition under which the enforcer causes a mainchain block to be invalidated, and the call chain that gets it there.                                           |
 | [`NON-INVALIDATING-RESOLUTION.md`](./NON-INVALIDATING-RESOLUTION.md) | Sorts all 29 rejection conditions into convertible now (13), convertible with a design change (6), and irreducible (9). Source of the extended documents' Appendix B. |
+| [`OPEN-QUESTIONS.md`](./OPEN-QUESTIONS.md)                           | Every unsettled item across both BIPs, in the order they should be decided, with what each one blocks.                                                                |
 
 ## Prior specifications
 
@@ -50,11 +51,40 @@ one of the three inputs to it; the unified documents supersede them.
 
 ## Open questions
 
+**[`OPEN-QUESTIONS.md`](./OPEN-QUESTIONS.md) is the agenda** — every unsettled
+item in dependency order, with what each one blocks and what is being asked.
+Start there rather than with the list below, which is a summary of the same
+items.
+
+Four items in BIP-300's Appendix A and two in BIP-301's are not settled. The
+unified documents state the implementation's behaviour in the body and record
+the question in the appendix; none of them is resolved by fiat.
+
 - **The M2 header byte is unresolved.** Both the original BIP-300 and
   `bip300.md` give `D6 E1 C5 BF`; the implementation uses `D6 E1 C5 DF`. Nothing
   in any source reveals which is correct. The unified documents follow the
   implementation and mark this UNRESOLVED — see Appendix A, item 1. It needs
   author input.
+- **The treasury UTXO of an overwritten sidechain slot is unspecified.**
+  `bip300.md` asks the question and no source answers it. Read literally, the
+  rules hand the incoming sidechain the outgoing sidechain's funds. This is a
+  fund-safety decision — see Appendix A, item 12.
+- **Whether to restore the one-proposal-per-block limit.** The original draft
+  allowed one M1 per block, and one M3 per slot per block, as a rate limit
+  against proposal spam and against overloading miner attention. The enforcer
+  rejects only exact duplicates. Restoring the limit means changing the
+  enforcer, not the documents — see Appendix A, item 9.
+- **Whether `OP_DRIVECHAIN` should move off `OP_NOP5`.** `OP_NOP8` or `OP_NOP9`
+  has been proposed, to stay clear of the numbers a future Bitcoin Core soft
+  fork is most likely to want. The choice is arbitrary and costs nothing to
+  change while nothing is deployed on mainnet; two candidates have been named
+  and one must be picked — see Appendix A, item 13.
+- **BIP-301's M8 wire format is provisional.** BMM bidding and accepting are
+  being reworked. The M8 encoding in both prior drafts — output index, 3-byte
+  tag, byte-exact script — descends from a superseded design in which a BMM
+  request was a distinct transaction type, not an ordinary transaction with an
+  `OP_RETURN`. BIP-301 Appendix A, items 3, 5 and 7 record what is enforced
+  today and separate it from the four rules any redesign must preserve.
 
 ## Development
 

--- a/bip300-unified-extended.mediawiki
+++ b/bip300-unified-extended.mediawiki
@@ -1,0 +1,791 @@
+<pre>
+  BIP: 300
+  Layer: Consensus (soft fork)
+  Title: Hashrate Escrows (Consensus layer)
+  Authors: Paul Sztorc <truthcoin@gmail.com>
+           CryptAxe <cryptaxe@gmail.com>
+           Roberto Santacroce <roberto@santacroce.xyz>
+  Status: Draft
+  Type: Specification
+  Assigned: 2017-08-14
+  License: BSD-2-Clause
+  Discussion: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-May/014364.html
+</pre>
+
+''This document unifies the original BIP-300 draft with the LayerTwo-Labs
+protocol specification, and reconciles both against the reference
+implementation. Every point on which the three sources disagreed is listed in
+Appendix A, together with the resolution and the evidence for it.''
+
+'''This is the extended variant.''' It additionally adopts the deterministic
+resolution rules of Appendix B in place of a number of block rejections, and so
+'''does change behaviour'''. The baseline variant —
+<code>bip300-unified.mediawiki</code> — carries the same reconciliation with
+none of those changes, and is the document to read first. Reviewers evaluating
+the reconciliation alone should use the baseline; this variant is for evaluating
+the reconciliation ''and'' the proposed relaxations together.
+
+==Abstract==
+
+BIP-300 enables a new type of L2, where "withdrawals" (the L2-to-L1 txns) are
+governed by proof-of-work — instead of a federation or fixed set of pubkeys.
+
+BIP-300 emphasizes slow, transparent, and auditable withdrawals that are easy
+for honest users to get right and hard for dishonest miners to abuse. The main
+design goal for BIP-300 is ''partitioning'' — users can ignore BIP-300 txns if
+they wish; it makes no difference to L1 if the user validates all, some, or none
+of them. The second design goal is ''security'' — users of the L2 should feel
+confident that, if the L2 network is paying a lot of fees, then miners will want
+to keep it around, and the withdrawals will therefore be processed accurately.
+
+==Motivation==
+
+BIP-300 allows Bitcoin to host L2 systems whose peg is secured by hashrate
+rather than by a trusted federation. See [http://www.drivechain.info/
+drivechain.info] for background and rationale.
+
+==Conventions==
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in RFC 2119.
+
+Three dispositions are used throughout, and are '''not''' interchangeable:
+
+* '''ignored''' — the message is not a BIP-300 message at all. It is treated as an ordinary script/transaction. No state changes. The block remains valid.
+* '''invalid (message)''' — the message parses as BIP-300 but violates a rule. Unless stated otherwise, this causes the block to be rejected.
+* '''invalid (block)''' — the block MUST be rejected by BIP-300 enforcing nodes.
+
+Bitcoin nodes that do not enforce BIP-300 accept all of these blocks. BIP-300
+validity is strictly narrower than Bitcoin validity, which is what makes this a
+soft fork.
+
+==Constants==
+
+<pre>
+WITHDRAWAL_BUNDLE_MAX_AGE                  = 26300
+WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD      = 13150
+
+USED_SIDECHAIN_SLOT_PROPOSAL_MAX_AGE       = 26300
+USED_SIDECHAIN_SLOT_ACTIVATION_THRESHOLD   = 13150
+
+UNUSED_SIDECHAIN_SLOT_PROPOSAL_MAX_AGE     = 2016
+UNUSED_SIDECHAIN_SLOT_ACTIVATION_THRESHOLD = 1815
+</pre>
+
+All threshold comparisons are '''strict'''. A proposal or bundle succeeds when
+its vote count is '''greater than''' the threshold, i.e. a withdrawal bundle
+requires 13151 ACKs, not 13150. See Appendix A, item 6.
+
+Non-mainnet networks MAY substitute shorter values so that a full
+activation/withdrawal cycle is testable. Such values are consensus-relevant per
+network and MUST be agreed by all enforcing nodes on that network.
+
+==Message headers==
+
+<pre>
+M1: 0x6A 0xD5 0xE0 0xC4 0xAF
+M2: 0x6A 0xD6 0xE1 0xC5 0xDF     (see Appendix A, item 1 — UNRESOLVED)
+M3: 0x6A 0xD4 0x5A 0xA9 0x43
+M4: 0x6A 0xD7 0x7D 0x17 0x76
+</pre>
+
+M5 and M6 are not tagged messages; they are identified structurally, by their
+relationship to a treasury UTXO (see below).
+
+==Specification==
+
+===Overview===
+
+BIP-300 consists of six messages:
+
+* M1. "Propose New Sidechain"  — coinbase output
+* M2. "ACK Proposal"           — coinbase output
+* M3. "Propose Bundle"         — coinbase output
+* M4. "ACK Bundle(s)"          — coinbase output
+* M5. Deposit (L1→L2)          — ordinary transaction
+* M6. Withdrawal (L2→L1)       — ordinary transaction
+
+Enforcing nodes maintain two logical databases:
+
+* D1. The Sidechain List
+* D2. The Withdrawal List
+
+===D1 — The Sidechain List===
+
+D1 holds one entry per sidechain slot. Slots are identified by a single unsigned
+byte <code>S</code> (0–255).
+
+{| class="wikitable"
+! Field !! Type !! Description
+|-
+| Slot number || uint8 || The slot's ID. Uniquely identifies each sidechain.
+|-
+| Description || bytes || Opaque sidechain description <code>D</code>. Not interpreted by BIP-300.
+|-
+| Active || bool || Whether this slot holds an activated sidechain.
+|-
+| Vote count || uint16 || ACKs accumulated by the proposal.
+|-
+| Proposal height || uint32 || Height of the block containing the M1.
+|-
+| Activation height || uint32 (optional) || Height at which the proposal activated.
+|-
+| CTIP outpoint || (txid, vout) || The treasury UTXO holding the sidechain's funds.
+|-
+| CTIP value || amount || Value of the treasury UTXO.
+|}
+
+'''On the sidechain description.''' The original draft specified a structured
+serialization (nSidechain, nVersion, title, description, hashID1, hashID2). This
+specification treats <code>D</code> as an '''opaque byte array''', per the
+LayerTwo-Labs draft and the reference implementation. Any internal structure is
+a convention between sidechain authors and their users, and is explicitly '''not
+enforced''' by BIP-300. The original draft already conceded this for hashID1 and
+hashID2 ("not enforced by BIP-300, and is for human purposes only"); this
+specification extends that treatment to the whole field, which removes a parsing
+surface from consensus code.
+
+===D2 — The Withdrawal List===
+
+Withdrawals are aggregated on L2 into "bundles". D2 holds the pending bundles
+per slot.
+
+{| class="wikitable"
+! Field !! Type !! Description
+|-
+| Slot number || uint8 || Links the bundle to a sidechain.
+|-
+| M6ID || uint256 || Blinded transaction ID of the withdrawal (see M6).
+|-
+| Vote count || uint16 || Miner upvotes. Starts at 1. Changes by at most 1 per block.
+|-
+| Proposal height || uint32 || Height of the block containing the M3.
+|}
+
+A bundle's <code>age</code> is <code>current_height - proposal_height</code>. A
+bundle is ''pending'' from the block that proposes it until it is either ''paid
+out'' (an M6 with the matching M6ID is included) or ''expired''
+(<code>age > WITHDRAWAL_BUNDLE_MAX_AGE</code>).
+
+Bundles maintain the following invariants:
+
+# The list has a canonical order: ascending by proposal height, then by coinbase output index within a block.
+# Vote counts change by at most 1 per block, in either direction, and saturate at zero.
+# A bundle whose vote count exceeds <code>WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD</code> is eligible for payout.
+# A bundle that expires is removed and pays nothing.
+
+===OP_DRIVECHAIN===
+
+This proposal adds a single new opcode. <code>OP_NOP5</code> (<code>0xB4</code>)
+is redefined as <code>OP_DRIVECHAIN</code> if and only if the entire script is
+exactly:
+
+<pre>
+OP_DRIVECHAIN OP_PUSHBYTES_1 <S> OP_TRUE
+</pre>
+
+which is exactly 4 bytes. <code>S</code> is the sidechain slot number, encoded as
+a raw unsigned byte. It is '''not''' a script number: it MUST NOT be encoded as
+<code>OP_1</code>..<code>OP_16</code> or any other push form, MUST NOT be
+sign-padded, and MUST be written as-is even for values above 127.
+
+The trailing <code>OP_TRUE</code> keeps the change a soft fork: without it, slot
+numbers 0 and 128 would cause the legacy script interpreter to fail.
+
+An output with this scriptPubKey is a '''treasury UTXO''' (historically "CTIP").
+When a treasury UTXO is spent, the additional rules of M5 or M6 MUST be
+enforced.
+
+'''There MUST never be two treasury UTXOs for the same sidechain slot.''' This
+is the central fund-safety invariant of BIP-300.
+
+===M1 — Propose Sidechain===
+
+====Encoding====
+
+<pre>
+OP_RETURN 0xD5 0xE0 0xC4 0xAF <S> <D>
+</pre>
+
+<code>S</code> is exactly 1 byte. <code>D</code> is all remaining bytes of the
+script, and is opaque. Its length is bounded only by Bitcoin's own rules.
+
+M1 MUST appear in an output of the coinbase transaction. An M1-shaped script in
+any non-coinbase transaction MUST be '''ignored'''. The output's
+<code>nValue</code> MUST be ignored.
+
+Define <code>proposal_id = sha256d(D)</code>.
+
+====Semantics====
+
+An M1 proposes that the sidechain described by <code>D</code> occupy slot
+<code>S</code>. If the slot is unused, the proposal is to '''activate'''. If the
+slot is used, the proposal is to '''overwrite''' the sidechain currently in it.
+After an overwrite, deposits to and withdrawals from the old sidechain are no
+longer recognised by BIP-300.
+
+====Validation====
+
+An M1 is '''ignored''' if it is not in a coinbase output.
+
+If a proposal with the same <code>(S, proposal_id)</code> already exists in D1,
+the M1 MUST be '''ignored''' — it MUST NOT reset the existing vote count.
+Without this rule a miner could reset any proposal's progress at will.
+
+A coinbase MAY contain multiple M1s with the same <code>S</code> and different
+<code>D</code>, or with different <code>S</code> and the same <code>D</code>.
+
+Two M1s with the same <code>(S, proposal_id)</code> in one coinbase are resolved
+by the same rule: the first creates the D1 entry, and every later one is
+'''ignored''' because the proposal now exists.
+
+''The original draft made any second M1 in a block invalidate it, regardless of
+content, and the LayerTwo-Labs draft and the implementation invalidate on exact
+duplicates. See Appendix A, item 9; this specification resolves them
+deterministically instead — see Appendix B, item 1.''
+
+Otherwise, a new D1 entry is created with <code>vote_count = 0</code>,
+<code>proposal_height = </code> the height of this block, and
+<code>active = false</code>.
+
+===M2 — ACK Sidechain Proposal===
+
+====Encoding====
+
+<pre>
+OP_RETURN 0xD6 0xE1 0xC5 0xDF <S> <proposal_id>
+</pre>
+
+A ''well-formed'' M2 script is exactly '''38 bytes''': the 5-byte header, 1 byte
+of <code>S</code>, and 32 bytes of <code>proposal_id</code>. Anything else MUST
+be '''ignored'''.
+
+''The original draft omitted the <code>S</code> byte entirely (37 bytes). This
+specification adopts the LayerTwo-Labs form, which the reference implementation
+also uses. See Appendix A, item 2. On the header byte, see Appendix A, item 1 —
+this is an unresolved discrepancy requiring author input.''
+
+====Semantics====
+
+An M2 is '''ignored''' if:
+
+* it is not within a coinbase output;
+* it is not well-formed;
+* <code>proposal_id</code> does not match any proposal created by an M1 in a previous block; or
+* <code>S</code> does not match the <code>sidechain_number</code> of that proposal.
+
+Otherwise the M2 is ''valid'' and the proposal's vote count is incremented by 1.
+
+If a coinbase transaction contains more than one valid M2 with the same
+<code>S</code>, only the one at the '''lowest output index''' is applied; the
+rest MUST be '''ignored''', regardless of their <code>proposal_id</code> values.
+A slot's vote count therefore never moves by more than 1 in a block.
+
+''The prior drafts invalidated the block instead. See Appendix B, item 2.''
+
+A proposal that receives no M2 in a block accrues an implicit "fail" for that
+block; <code>fails = age - vote_count</code>.
+
+====Activation====
+
+Let <code>age = current_height - proposal_height</code>.
+
+A proposal '''activates''' when:
+
+* the slot is '''unused''', <code>vote_count > UNUSED_SIDECHAIN_SLOT_ACTIVATION_THRESHOLD</code>, and <code>age <= UNUSED_SIDECHAIN_SLOT_PROPOSAL_MAX_AGE</code>; or
+* the slot is '''used''', <code>vote_count > USED_SIDECHAIN_SLOT_ACTIVATION_THRESHOLD</code>, and <code>age <= USED_SIDECHAIN_SLOT_PROPOSAL_MAX_AGE</code>.
+
+A proposal '''fails''' (and is discarded) when its age exceeds the relevant
+<code>MAX_AGE</code> without activating.
+
+The unused-slot threshold of 1815 out of 2016 blocks is a '''90%''' hashrate
+bar, not the 50% bar implied by the original draft. See Appendix A, item 3.
+
+===M3 — Propose Bundle===
+
+====Encoding====
+
+<pre>
+OP_RETURN 0xD4 0x5A 0xA9 0x43 <S> <M6ID>
+</pre>
+
+A ''well-formed'' M3 script is exactly 38 bytes: 5-byte header, 1 byte
+<code>S</code>, 32 bytes <code>M6ID</code>. Anything else MUST be '''ignored'''.
+
+====Validation====
+
+An M3 is '''ignored''' if it is not in a coinbase output, is not well-formed, or
+names a slot that is not active.
+
+''The original draft and the LayerTwo-Labs draft both invalidated the block for
+an inactive slot; the LayerTwo-Labs draft flags this as an open question. This
+specification ignores it — see Appendix B, item 4.''
+
+If the named <code>M6ID</code> is '''already pending''' for slot <code>S</code>,
+the M3 MUST be '''ignored''' (it MUST NOT reset the vote count), by the same
+reasoning as the M1 duplicate rule. This covers duplicates within a single
+coinbase as well: the first M3 makes the bundle pending, so any later M3 with
+the same <code>(S, M6ID)</code> in that block is ignored.
+
+A coinbase MAY contain multiple M3s with the same <code>S</code> and different
+<code>M6ID</code>, or with different <code>S</code> and the same
+<code>M6ID</code>.
+
+''The original draft invalidated the block for a second M3 for the same slot
+regardless of content; the LayerTwo-Labs draft and the implementation both
+permit it. See Appendix A, item 9, and Appendix B, item 10.''
+
+An <code>M6ID</code> that is no longer pending — because it expired or was paid
+out — MAY be proposed again, starting a fresh vote count and expiry.
+
+''This replaces the original draft's permanent blacklist ("a bundle with this
+hash already paid out" / "was rejected in the past"). See Appendix A, item 4.''
+
+Otherwise, a D2 entry is created with <code>vote_count = 1</code> and
+<code>proposal_height = </code> this block's height. Being proposed counts as
+the bundle's first upvote.
+
+===M4 — ACK Bundle(s)===
+
+====Encoding====
+
+<pre>
+OP_RETURN 0xD7 0x7D 0x17 0x76 <V> [A]
+</pre>
+
+<code>V</code> selects the version:
+
+{| class="wikitable"
+! V !! Name !! Body
+|-
+| 0x00 || <code>REPEAT_PREVIOUS</code> || none (script is exactly 6 bytes)
+|-
+| 0x01 || <code>VOTES_ONE_BYTE</code> || array of uint8
+|-
+| 0x02 || <code>VOTES_TWO_BYTE</code> || array of uint16, little-endian
+|-
+| 0x03 || <code>UPVOTE_LEADING_BY_50</code> || none (script is exactly 6 bytes)
+|}
+
+A coinbase transaction SHOULD contain at most one M4. If it contains more than
+one, only the M4 at the '''lowest output index''' is applied; the rest MUST be
+'''ignored'''.
+
+''The prior drafts invalidated the block instead. See Appendix B, item 3.''
+
+If no M4 is present, the block abstains for every slot.
+
+====Slot indexing====
+
+Active slot numbers may be sparse, so array positions are '''not''' slot
+numbers. Enforcing nodes MUST:
+
+# Collect all active slot numbers into a vector <code>ASN</code>.
+# Sort <code>ASN</code> ascending.
+# Interpret <code>A[i]</code> as the vote for slot <code>ASN[i]</code>.
+
+====Bundle indexing====
+
+Within a slot, <code>A[i]</code> selects a bundle by position in the slot's
+pending list, sorted ascending by proposal height, ties broken by coinbase
+output index. Sentinel values:
+
+{| class="wikitable"
+! Meaning !! VOTES_ONE_BYTE !! VOTES_TWO_BYTE
+|-
+| ALARM || 0xFE || 0xFFFE
+|-
+| ABSTAIN || 0xFF || 0xFFFF
+|}
+
+====Vote semantics====
+
+For each slot <code>S_i</code> with vote <code>V_i</code>:
+
+* '''M6ID selected''' — that bundle gains 1 ACK; every other pending bundle in <code>S_i</code> loses 1.
+* '''ABSTAIN''' — no vote counts in <code>S_i</code> change.
+* '''ALARM''' — every pending bundle in <code>S_i</code> loses 1.
+
+Vote counts saturate at zero; they MUST NOT underflow.
+
+<code>REPEAT_PREVIOUS</code> casts the votes the previous block's M4 resolved
+to. Repeats chain transitively. Repeating an <code>UPVOTE_LEADING_BY_50</code>
+MUST NOT re-evaluate the leading-by-50 rule against current counts; it replays
+the resolved votes. If the previous block had no M4, or its M4 resolved to no
+votes, <code>REPEAT_PREVIOUS</code> casts no votes. A repeated upvote naming a
+bundle that is no longer pending casts no vote in that slot, and MUST NOT
+invalidate the block.
+
+<code>UPVOTE_LEADING_BY_50</code>, per slot: if some bundle leads every other
+bundle in that slot by at least 50 votes, upvote it (and downvote the rest);
+otherwise abstain in that slot.
+
+====Mandatory payout====
+
+When a bundle's vote count exceeds
+<code>WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD</code>, the block in which this
+happens MUST include the corresponding M6. A block that does not is '''invalid
+(block)'''.
+
+This rule is retained as a hard rejection. It is the only mechanism forcing an
+approved withdrawal to actually be paid; converting it to a deterministic
+fallback would let miners indefinitely stall an approved bundle at no cost.
+There is nothing to select — the required transaction is simply absent.
+
+''A design change would remove the need for it: making approval'' sticky ''—
+exempting an approved bundle from expiry, allowing at most one per slot, and
+permitting revocation only by sustained ALARM votes — reduces omission from a
+kill to a delay, at which point the rejection buys nothing. That change is
+specified in the companion document, ''Non-Invalidating Resolution for
+BIP-300/301'', §5.2, and is not adopted here: it alters the withdrawal state
+machine and wants adversarial review first.''
+
+====Malformed vote arrays====
+
+''The original and LayerTwo-Labs drafts invalidate the block when the array is
+longer than the active-slot vector, when a bundle index is out of range, or when
+<code>VOTES_TWO_BYTE</code> is used unnecessarily. The LayerTwo-Labs draft
+raises all three as open questions. This specification resolves them without
+rejection — see Appendix B, items 5–7.''
+
+===M5 — Deposit (L1 → L2)===
+
+====Semantics====
+
+An M5 moves coins from L1 into a sidechain's treasury. A transaction is an M5 if
+it creates a treasury UTXO for slot <code>S</code> whose value is '''greater
+than''' the value of the treasury UTXO it spent (or greater than zero, for the
+first ever deposit to that slot).
+
+====Structure====
+
+An M5 MUST have:
+
+# Exactly one treasury UTXO output for slot <code>S</code>, which becomes the new CTIP.
+# An address output immediately following the treasury output in <code>vout</code>: <code>OP_RETURN <A></code>, where <code>A</code> is an opaque sidechain address. Its <code>nValue</code> MUST be ignored.
+# An input spending the previous treasury UTXO for <code>S</code>, if one exists. If none exists, the previous treasury value is defined as 0.
+
+The slot number in the spent treasury UTXO MUST equal the slot number in the
+created one.
+
+<code>A</code> MUST be treated by enforcing nodes as a meaningless byte array.
+Its interpretation is the sidechain's business.
+
+====Deposit value recovery====
+
+The deposit amount is <code>V = T_new - T_old</code>. A treasury UTXO alone does
+not reveal <code>V</code>; recovering it requires the spent output's value.
+Enforcing nodes SHOULD index <code>(S, n) → (height, V, T, A)</code> so that
+deposits can be served without rescanning the chain, where <code>n</code> is a
+per-slot sequence number.
+
+Withdrawals (M6) MUST consume a sequence number, leaving a gap in the deposit
+sequence, so that the sequence records the full ordered history of treasury
+movements rather than deposits alone.
+
+====Missing address output====
+
+''Both prior drafts invalidate the block when the address output is absent. This
+specification instead accepts the treasury movement and credits no depositor —
+see Appendix B, item 8.''
+
+===M6 — Withdrawal (L2 → L1)===
+
+====Semantics====
+
+An M6 moves coins out of a sidechain's treasury to L1 addresses. A transaction
+is an M6 if it spends a treasury UTXO and creates one whose value is '''less
+than''' the spent value.
+
+====Structure====
+
+An M6 MUST:
+
+# have '''exactly one input''', spending the treasury UTXO of slot <code>S</code>;
+# have the new treasury UTXO at '''<code>vout[0]</code>''', with the same slot number <code>S</code>;
+# have all withdrawal payout outputs at indices 1..n;
+# contain '''no''' additional <code>OP_DRIVECHAIN</code> outputs.
+
+Let <code>T_prev</code> be the spent treasury value, <code>T_new</code> the
+created treasury value, <code>P_total</code> the sum of all payout outputs, and
+<code>F_total</code> the transaction fee. Then:
+
+<pre>
+T_new = T_prev - P_total - F_total
+</pre>
+
+====M6ID and the blinded form====
+
+Bundles are voted on months before the treasury UTXO they will spend exists.
+Votes therefore commit to a '''blinded''' form of the transaction, not its final
+txid.
+
+<code>M6_blinded</code> differs from the final M6 in exactly two ways:
+
+# its <code>vin</code> is '''empty''';
+# <code>vout[0]</code> is a zero-value <code>OP_RETURN <F_total></code>, where <code>F_total</code> is a 64-bit unsigned integer encoded as '''8 bytes, big-endian''' — occupying the same index the treasury UTXO occupies in the final M6.
+
+<code>M6ID = txid(M6_blinded)</code>.
+
+Constructing the final M6 from the blinded form is therefore: replace
+<code>vout[0]</code> with the treasury output, and add the single treasury
+input. Nothing else changes, which is what lets the vote bind the payouts and
+the fee while leaving the treasury outpoint free.
+
+'''Both prior drafts specify this incorrectly and in different ways.''' See
+Appendix A, item 5. The layout above is the one the reference implementation
+uses and is the only one consistent with M6ID being stable across the treasury's
+lifetime.
+
+The blinded form MUST have a non-zero total payout.
+
+====Validation====
+
+An M6 is '''invalid (block)''' if any of the following hold:
+
+* its <code>M6ID</code> does not match a pending bundle for slot <code>S</code>;
+* that bundle's vote count does not exceed <code>WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD</code>;
+* that bundle's <code>age > WITHDRAWAL_BUNDLE_MAX_AGE</code>;
+* it has more or fewer than one input;
+* <code>vout[0]</code> is not a treasury UTXO for <code>S</code>;
+* it contains any further <code>OP_DRIVECHAIN</code> output;
+* the arithmetic above does not hold.
+
+'''Every rule in this list is retained as a hard rejection.''' These are the
+rules that keep coins from leaving a treasury without hashrate approval. See the
+companion document on non-invalidating resolution for why this family is not
+convertible.
+
+===Transaction validation===
+
+A transaction that spends a treasury UTXO and does not create a new treasury
+UTXO for the same slot is '''invalid (block)'''.
+
+A transaction that creates a treasury UTXO for a slot whose treasury UTXO
+already exists, without spending it, is '''invalid (block)'''.
+
+A transaction that spends a treasury UTXO and creates a new one of '''equal'''
+value is a no-op: it is accepted, the CTIP is updated, and no deposit or
+withdrawal is recorded. ''The prior drafts invalidated the block; see Appendix
+B, item 9.''
+
+A transaction that appears to satisfy both the M5 and M6 structural rules is
+classified by its '''value delta''', not rejected: <code>T_new > T_old</code> is
+an M5, <code>T_new < T_old</code> is an M6, and equality is the no-op above.
+Once classified, the normal M5 or M6 rules apply unchanged — a transaction that
+fails the M6 rules still fails them. ''The prior drafts rejected the block; see
+Appendix B, item 11.''
+
+M1–M4 never appear outside a coinbase transaction. An M1/M2/M3/M4-shaped
+OP_RETURN in a non-coinbase transaction MUST be '''ignored'''.
+
+The coinbase transaction never contains a treasury UTXO. A treasury-shaped
+output in a coinbase MUST be '''ignored'''.
+
+===Block validation===
+
+A block is '''invalid (block)''' if:
+
+* any non-coinbase transaction is invalid per the rules above;
+* it contains no transactions, i.e. has no coinbase;
+* any coinbase-message rule above is violated.
+
+Note that the coinbase-message rules retained by this specification are far
+fewer than in the baseline: the cases listed in Appendix B are resolved rather
+than rejected, and so are no longer violations.
+
+==Rationale==
+
+===Why thresholds are strict===
+
+Both drafts describe the withdrawal threshold in prose as "reaches 13150 or
+greater", but the reference implementation compares strictly
+(<code>vote_count > threshold</code>). Since a bundle starts at 1 ACK on
+proposal and can gain at most 1 per block, the difference is one full block of
+hashrate approval on a 26300-block clock. This specification adopts the strict
+comparison and states it once, globally, rather than restating it per message.
+
+===Why the sidechain description is opaque===
+
+Consensus code should parse as little attacker-supplied structure as possible.
+The original draft's structured description added a parser to the consensus path
+whose only enforced property was that it parsed. Treating <code>D</code> as
+opaque and identifying proposals by <code>sha256d(D)</code> removes that surface
+without losing any enforced guarantee.
+
+===Why re-proposal is allowed===
+
+The original draft permanently blacklisted any bundle hash that was paid out or
+rejected. This is unnecessary for safety — a bundle that is paid out cannot be
+paid out twice, because the treasury UTXO it spent no longer exists — and it is
+harmful in practice, because a bundle that expires through miner apathy could
+never be retried, stranding those withdrawals forever. Allowing re-proposal with
+a fresh counter preserves safety and removes a permanent-state requirement.
+
+==Backward compatibility==
+
+This soft fork can be deployed without modifying Bitcoin Core. Non-enforcing
+nodes accept every block that enforcing nodes accept, and additionally accept
+blocks that enforcing nodes reject.
+
+==Deployment==
+
+This BIP deploys when/if a majority of hashrate runs the enforcer client.
+
+Ideally a critical mass of users would also run it, which would strongly
+dissuade miners from de-activating it.
+
+==Reference implementation==
+
+[https://github.com/LayerTwo-Labs/bip300301_enforcer/ bip300301_enforcer], with
+the mempool/driver layer in
+[https://github.com/LayerTwo-Labs/cusf-enforcer-mempool/ cusf-enforcer-mempool].
+
+==Appendix A — Reconciliation of prior drafts==
+
+Each item lists the disagreement, the resolution, and the evidence.
+
+'''1. M2 header byte — UNRESOLVED, requires author input.'''
+
+{| class="wikitable"
+! Source !! Value
+|-
+| Original BIP-300 || <code>D6 E1 C5 BF</code>
+|-
+| LayerTwo-Labs draft || <code>D6 E1 C5 BF</code>
+|-
+| Reference implementation || <code>D6 E1 C5 DF</code>
+|}
+
+The implementation disagrees with both specifications in the final byte. This
+document tentatively follows the implementation, since that is what is deployed
+and what any interoperating software must match today, but '''this must be
+confirmed by the authors before publication'''. If the specs are correct, the
+implementation has a wire-format bug; if the implementation is correct, both
+specs do. There is no way to tell from the documents alone.
+
+'''2. M2 length and slot byte.''' Original: 37 bytes, no slot number.
+LayerTwo-Labs: 38 bytes, with a 1-byte slot. Resolved in favour of 38 bytes; the
+implementation parses 1 byte of slot followed by 32 bytes of hash and rejects
+trailing data. Without the slot byte an M2 cannot be checked against the slot
+its proposal targets.
+
+'''3. Unused-slot activation threshold.''' Original: 1008 fails out of 2016
+blocks (50%). LayerTwo-Labs: 201 max fails, threshold 1815 (90%). Resolved in
+favour of 1815, per the implementation's <code>Thresholds::MAINNET</code>. This
+is a substantive policy difference, not an editorial one: it raises the bar for
+claiming an empty slot from a bare majority of hashrate to a supermajority.
+Reviewers should treat it as a deliberate change and confirm intent.
+
+'''4. Bundle re-proposal.''' Original: a bundle hash that was ever paid out or
+rejected is permanently barred. LayerTwo-Labs: only ''pending'' hashes are
+barred. Resolved in favour of the LayerTwo-Labs rule; see Rationale.
+
+'''5. M6 output layout.''' The two drafts and the implementation all differ:
+
+{| class="wikitable"
+! Source !! Treasury in M6 !! Fee OP_RETURN
+|-
+| Original BIP-300 || <code>vout[0]</code> || retained in the final M6 at <code>vout[1]</code>
+|-
+| LayerTwo-Labs || <code>vout[0]</code> in one paragraph, "last output" in two others || appended to the '''end''' of the blinded <code>vout</code>
+|-
+| Implementation || <code>vout[0]</code> || <code>vout[0]</code> of the '''blinded''' form only; replaced by the treasury output in the final M6
+|}
+
+The LayerTwo-Labs draft is internally inconsistent — it states index 0 when
+describing the M6 and "always the last output" when describing
+<code>m6_to_id</code>. Resolved in favour of the implementation: index 0 in both
+forms, with the fee OP_RETURN existing only in the blinded form. This is the
+only reading under which <code>M6ID</code> is computable before the treasury
+outpoint is known, which is the entire purpose of blinding.
+
+'''6. Threshold comparison.''' Original prose implies <code>>=</code>;
+LayerTwo-Labs and the implementation use <code>></code>. Resolved in favour of
+<code>></code>.
+
+'''7. M4 index bases.''' The original draft's worked example is internally
+inconsistent — it labels a message "version 00" (which carries no vote array)
+while showing a two-element array, and its "7th bundle / 4th bundle" prose does
+not match the bytes shown. The LayerTwo-Labs indexing algorithm (sorted active
+slots, chronologically sorted bundles, zero-based) is adopted, and the original
+example is dropped rather than repaired.
+
+'''8. Sidechain description structure.''' Original: structured (nSidechain,
+nVersion, title, description, hashID1, hashID2). LayerTwo-Labs and
+implementation: opaque bytes. Resolved in favour of opaque; see Rationale.
+
+'''9. Duplicate M1 and M3 scope.''' Original: a second M1 in a block, or a
+second M3 for the same slot, invalidates the block regardless of content.
+LayerTwo-Labs and implementation: only exact duplicates
+(<code>(S, proposal_id)</code> for M1, <code>(S, M6ID)</code> for M3) invalidate;
+differing content in the same slot is permitted. Resolved in favour of the
+narrower rule — and then, in this variant, resolved deterministically rather
+than by rejection; see Appendix B, item 1.
+
+'''10. M5 address output.''' Original: not required — an M5 is valid if it has
+one OP_DRIVECHAIN output and more coins than before. LayerTwo-Labs and
+implementation: an address <code>OP_RETURN</code> MUST immediately follow the
+treasury output. The requirement is adopted, but this variant does not enforce
+it by rejection; see Appendix B, item 8.
+
+'''11. M4 open questions.''' The LayerTwo-Labs draft marks three of its own
+rules with "???" — the over-long vote array, the out-of-range bundle index, and
+the unnecessary two-byte encoding. The baseline retains all three as specified.
+This variant answers all three; see Appendix B, items 5–7.
+
+==Appendix B — Deterministic resolution in place of block rejection==
+
+The prior drafts reject the block in a number of cases where the ambiguity can
+instead be resolved deterministically. Every enforcing node computes the same
+resolution from the block and prior state alone, so consensus is preserved
+without discarding an otherwise valid block.
+
+{| class="wikitable"
+! # !! Condition !! Prior drafts !! This specification
+|-
+| 1 || Duplicate M1 (same S, same D) || block invalid || ignore all but the first
+|-
+| 2 || Duplicate M2 for a slot || block invalid || apply the first, ignore the rest
+|-
+| 3 || Duplicate M4 in a coinbase || block invalid || apply the first, ignore the rest
+|-
+| 4 || M3 for an inactive slot || block invalid || ignore the M3
+|-
+| 5 || M4 vote array longer than the active-slot vector || block invalid || apply votes for valid indices, ignore the excess
+|-
+| 6 || M4 bundle index out of range || block invalid || treat that slot's vote as ABSTAIN
+|-
+| 7 || <code>VOTES_TWO_BYTE</code> used where one byte would do || block invalid || accept; the wasted bytes are self-penalising
+|-
+| 8 || M5 with no address OP_RETURN || block invalid || accept the treasury movement, credit no depositor
+|-
+| 9 || Deposit or withdrawal of zero net value, i.e. an equal-value treasury respend || block invalid || accept as a CTIP move, record nothing
+|-
+| 10 || Duplicate M3 (same S, same M6ID) in one coinbase || block invalid || the first makes the bundle pending, the rest are ignored
+|-
+| 11 || Transaction satisfying both the M5 and M6 structural rules || block invalid || classify by value delta; the normal M5/M6 rules then apply
+|}
+
+Items 4, 5, 6 and 7 correspond exactly to the four open questions the
+LayerTwo-Labs draft raises with "???"; this specification answers all four in
+the same direction.
+
+The following are '''deliberately retained''' as block rejections, because for
+these the rejection is load-bearing rather than merely disambiguating: every
+M6 validation rule, the mandatory-payout rule, spending a treasury without
+recreating it, creating a second treasury for a live slot, any duplicate
+<code>OP_DRIVECHAIN</code> output, and a block with no coinbase. The reasoning
+is set out in the companion document, ''Non-Invalidating Resolution for
+BIP-300/301''.
+
+'''Deployment note.''' Every change in this appendix ''relaxes'' validity. A
+node running these rules accepts blocks that a node running the prior rules
+rejects. Between enforcer versions that is a chain-splitting change, not a soft
+fork, and it MUST be activated at an agreed height or before BIP-300 activates
+on mainnet — not rolled out incrementally.
+
+==Copyright==
+
+This BIP is licensed under the BSD 2-clause license.

--- a/bip300-unified-extended.mediawiki
+++ b/bip300-unified-extended.mediawiki
@@ -25,6 +25,12 @@ none of those changes, and is the document to read first. Reviewers evaluating
 the reconciliation alone should use the baseline; this variant is for evaluating
 the reconciliation ''and'' the proposed relaxations together.
 
+Four appendix items are marked '''UNRESOLVED''' or '''OPEN DECISION''' — items
+1, 9, 12 and 13. In each case the body states what the implementation does
+today, and the appendix states the question and what answering it would change.
+They need author input before publication, and item 9 in particular would
+withdraw two of Appendix B's resolutions.
+
 ==Abstract==
 
 BIP-300 enables a new type of L2, where "withdrawals" (the L2-to-L1 txns) are
@@ -193,6 +199,12 @@ sign-padded, and MUST be written as-is even for values above 127.
 The trailing <code>OP_TRUE</code> keeps the change a soft fork: without it, slot
 numbers 0 and 128 would cause the legacy script interpreter to fail.
 
+''Moving <code>OP_DRIVECHAIN</code> off <code>OP_NOP5</code> to
+<code>OP_NOP8</code> or <code>OP_NOP9</code> has been proposed, so that BIP-300
+does not sit on a number a future Bitcoin Core soft fork might want. The choice
+of NOP is arbitrary and nothing else in this document depends on it. This is an
+open decision; see Appendix A, item 13.''
+
 An output with this scriptPubKey is a '''treasury UTXO''' (historically "CTIP").
 When a treasury UTXO is spent, the additional rules of M5 or M6 MUST be
 enforced.
@@ -225,6 +237,11 @@ slot is used, the proposal is to '''overwrite''' the sidechain currently in it.
 After an overwrite, deposits to and withdrawals from the old sidechain are no
 longer recognised by BIP-300.
 
+''What becomes of the overwritten sidechain's treasury UTXO — and therefore of
+the funds in it — is not answered by any of the three sources, nor by this
+variant. See Appendix A, item 12; this is unresolved and requires author
+input.''
+
 ====Validation====
 
 An M1 is '''ignored''' if it is not in a coinbase output.
@@ -241,9 +258,11 @@ by the same rule: the first creates the D1 entry, and every later one is
 '''ignored''' because the proposal now exists.
 
 ''The original draft made any second M1 in a block invalidate it, regardless of
-content, and the LayerTwo-Labs draft and the implementation invalidate on exact
-duplicates. See Appendix A, item 9; this specification resolves them
-deterministically instead — see Appendix B, item 1.''
+content — a deliberate one-proposal-per-block rate limit — and the LayerTwo-Labs
+draft and the implementation invalidate on exact duplicates only. This
+specification resolves the duplicates deterministically instead; see Appendix B,
+item 1. Whether the original rate limit should be restored, which would withdraw
+that resolution, is an open decision; see Appendix A, item 9.''
 
 Otherwise, a new D1 entry is created with <code>vote_count = 0</code>,
 <code>proposal_height = </code> the height of this block, and
@@ -333,8 +352,9 @@ A coinbase MAY contain multiple M3s with the same <code>S</code> and different
 <code>M6ID</code>.
 
 ''The original draft invalidated the block for a second M3 for the same slot
-regardless of content; the LayerTwo-Labs draft and the implementation both
-permit it. See Appendix A, item 9, and Appendix B, item 10.''
+regardless of content — the same rate limit it applied to M1; the LayerTwo-Labs
+draft and the implementation both permit it. See Appendix B, item 10, and, for
+whether the rate limit should be restored, Appendix A, item 9.''
 
 An <code>M6ID</code> that is no longer pending — because it expired or was paid
 out — MAY be proposed again, starting a fresh vote count and expiry.
@@ -506,6 +526,17 @@ An M6 MUST:
 # have the new treasury UTXO at '''<code>vout[0]</code>''', with the same slot number <code>S</code>;
 # have all withdrawal payout outputs at indices 1..n;
 # contain '''no''' additional <code>OP_DRIVECHAIN</code> outputs.
+
+<code>vout[0]</code> '''is''' the change output. Whatever treasury balance
+remains after the bundle's payouts and the transaction fee is returned to the
+same slot's treasury as a single UTXO, and that UTXO becomes the slot's new
+CTIP. It is the only <code>OP_DRIVECHAIN</code> output an M6 may contain: a
+withdrawal never creates a second one, and never leaves the slot without one.
+This is unchanged from the original design — all three sources return the change
+to the treasury at <code>vout[0]</code>, and their disagreement in Appendix A,
+item 5 is about the fee <code>OP_RETURN</code>, not about the change. Appendix A,
+item 10 does not bear on it either; that item concerns deposits only, and
+nothing in Appendix B changes it.
 
 Let <code>T_prev</code> be the spent treasury value, <code>T_new</code> the
 created treasury value, <code>P_total</code> the sum of all payout outputs, and
@@ -716,13 +747,38 @@ example is dropped rather than repaired.
 nVersion, title, description, hashID1, hashID2). LayerTwo-Labs and
 implementation: opaque bytes. Resolved in favour of opaque; see Rationale.
 
-'''9. Duplicate M1 and M3 scope.''' Original: a second M1 in a block, or a
-second M3 for the same slot, invalidates the block regardless of content.
-LayerTwo-Labs and implementation: only exact duplicates
-(<code>(S, proposal_id)</code> for M1, <code>(S, M6ID)</code> for M3) invalidate;
-differing content in the same slot is permitted. Resolved in favour of the
-narrower rule — and then, in this variant, resolved deterministically rather
-than by rejection; see Appendix B, item 1.
+'''9. Duplicate M1 and M3 scope — OPEN DECISION, resolved provisionally.'''
+Original: a second M1 in a block, or a second M3 for the same slot, invalidates
+the block regardless of content. LayerTwo-Labs and implementation: only exact
+duplicates (<code>(S, proposal_id)</code> for M1, <code>(S, M6ID)</code> for M3)
+invalidate; differing content in the same slot is permitted. The body above
+follows the implementation, and this variant then resolves the remaining
+duplicates deterministically rather than by rejection; see Appendix B, items 1
+and 10.
+
+The narrowing was '''not''' a deliberate policy change. The original rule was a
+rate limit — one sidechain proposal per block — and it served two purposes:
+
+* '''Anti-spam and anti-blocking.''' One M1 per block means no miner can fill a coinbase with proposals, either to grief the slot table or to crowd out someone else's proposal. The same argument applies to M3 and bundle proposals.
+* '''Guarding miner attention.''' BIP-300 asks miners to form a judgement about each proposal. Metering proposals to one per block keeps that ask small, which was part of what made BIP-300 acceptable to miners at all.
+
+The current rule serves neither purpose. In review the authors restated the
+original intent: the one-per-block limit was deliberate, and the rapid
+activation of seven sidechains during testing was possible only because the
+limit is absent from the implementation.
+
+'''What is undecided''' is whether to restore it. Restoring it would mean an M1
+is valid only if it is the only M1 in its coinbase, an M3 only if it is the only
+M3 for its slot, and the reference implementation changing to match.
+
+Note the interaction with this variant specifically. Appendix B's approach is to
+replace rejections with deterministic resolution, and a restored rate limit
+points the other way: it is a rejection that exists to '''deter''' behaviour, not
+to disambiguate it. A rate limit resolved by "take the first and ignore the
+rest" is not a rate limit — the spam is free and simply has no effect, which
+defeats the miner-attention argument but not the slot-table one. If the limit is
+restored it belongs among the deliberately retained rejections at the end of
+Appendix B, and Appendix B items 1 and 10 are withdrawn.
 
 '''10. M5 address output.''' Original: not required — an M5 is valid if it has
 one OP_DRIVECHAIN output and more coins than before. LayerTwo-Labs and
@@ -730,10 +786,89 @@ implementation: an address <code>OP_RETURN</code> MUST immediately follow the
 treasury output. The requirement is adopted, but this variant does not enforce
 it by rejection; see Appendix B, item 8.
 
-'''11. M4 open questions.''' The LayerTwo-Labs draft marks three of its own
-rules with "???" — the over-long vote array, the out-of-range bundle index, and
-the unnecessary two-byte encoding. The baseline retains all three as specified.
-This variant answers all three; see Appendix B, items 5–7.
+This item concerns '''deposits only'''. It does not bear on how a withdrawal
+returns its change: an M6 returns the remaining treasury balance to the same
+slot's treasury UTXO at <code>vout[0]</code> and creates no other
+<code>OP_DRIVECHAIN</code> output, exactly as in the original design. An M6 has
+no address output — its payouts are ordinary L1 outputs, already committed to by
+the <code>M6ID</code> the miners voted on. Nothing in Appendix B changes this.
+
+'''11. M4 open questions.''' The LayerTwo-Labs draft raises three of its own M4
+rules as open questions. They appear as inline <code>??? QUESTION</code>
+comments in the body of the draft rather than in any list of open issues, which
+is what makes them easy to miss. They are quoted in full below, with their
+location in <code>bip300.md</code> as of this repository's current revision:
+
+{| class="wikitable"
+! Rule questioned !! Location !! Text of the comment !! Answered by
+|-
+| A vote array longer than the active-slot vector invalidates the block || M4, slot indexing (line 401) || ''??? QUESTION: Does the above make sense? Would it be better to ignore the excess votes in <code>A</code>?'' || Appendix B, item 5
+|-
+| An out-of-range bundle index invalidates the block || M4, <code>VOTES_ONE_BYTE</code> (line 441) || ''??? QUESTION: Would it make more sense to ignore the M4 with the index out of range error?'' || Appendix B, item 6
+|-
+| Using <code>VOTES_TWO_BYTE</code> where one byte would do invalidates the block || M4, <code>VOTES_TWO_BYTE</code> (line 470) || ''??? QUESTION: Does it make sense to enforce this rule?'' || Appendix B, item 7
+|}
+
+The baseline retains all three as specified; this variant answers all three in
+the direction the questions suggest.
+
+Two further open questions are marked the same way elsewhere in the draft and
+are '''not''' M4 questions. The first asks whether an M3 for an inactive slot
+should be ignored rather than invalidate the block (M3 conditions, line 1070,
+marked <code>/// ... ///</code> rather than <code>???</code>); Appendix B, item 4
+answers it. The second is item 12 below, which nothing answers.
+
+'''12. Treasury UTXO of an overwritten slot — UNRESOLVED, requires author
+input.''' The LayerTwo-Labs draft asks, at <code>bip300.md</code> line 773, at
+the end of the M5 section:
+
+''??? QUESTION: What happens to the treasury UTXO when a <code>used</code>
+sidechain slot is overwritten with a different sidechain? Does the same chain of
+treasury UTXOs continue?''
+
+Nothing answers it — not the original draft, not the LayerTwo-Labs draft, not
+the baseline, and not this variant. M1 above says only that deposits to and
+withdrawals from the overwritten sidechain stop being recognised, which says
+nothing about the UTXO itself.
+
+The rules as written admit only one reading. A treasury UTXO is identified
+solely by the slot number in its <code>scriptPubKey</code>; a slot has at most
+one; and an M1 overwrite changes the slot's description without touching the
+UTXO set. So the same chain of treasury UTXOs does continue, and the incoming
+sidechain inherits the outgoing sidechain's balance — which the outgoing
+sidechain's users can no longer withdraw, since their pending bundles name a
+sidechain the slot no longer describes.
+
+Whether that is the intended outcome is a fund-safety decision, not an editorial
+one, and it MUST be settled before publication. It is deliberately left out of
+Appendix B: this is a gap in the specification, not a block rejection that could
+be resolved deterministically. Note also that the 90% bar of item 3 applies to
+claiming an ''empty'' slot; overwriting a ''used'' slot needs only
+<code>USED_SIDECHAIN_SLOT_ACTIVATION_THRESHOLD</code>, a bare majority of
+hashrate sustained over 26300 blocks.
+
+'''13. Opcode choice — OPEN DECISION.''' All three sources use
+<code>OP_NOP5</code> (<code>0xB4</code>), and the body above states it. In
+review it was proposed that <code>OP_DRIVECHAIN</code> move to
+<code>OP_NOP8</code> (<code>0xB7</code>) or <code>OP_NOP9</code>
+(<code>0xB8</code>), on two grounds:
+
+* The choice is arbitrary. Nothing in BIP-300 depends on which NOP is redefined.
+* <code>OP_NOP4</code> through <code>OP_NOP7</code> are the numbers a future Bitcoin Core soft fork is most likely to reach for first, <code>OP_NOP2</code> and <code>OP_NOP3</code> having already been taken by <code>OP_CHECKLOCKTIMEVERIFY</code> and <code>OP_CHECKSEQUENCEVERIFY</code>. A collision with a real Core deployment would be far more costly to BIP-300 than choosing a different number now.
+
+The probability of such a collision is small. The cost of moving is currently
+near zero: BIP-300 is not deployed on mainnet, so no treasury UTXO exists whose
+<code>scriptPubKey</code> would have to change.
+
+A move touches the <code>OP_DRIVECHAIN</code> definition above, every treasury
+UTXO <code>scriptPubKey</code>, the reference implementation, and every
+sidechain implementation that constructs deposits or withdrawals. It does not
+touch M1–M4, which are <code>OP_RETURN</code> messages and carry no opcode, nor
+M7 and M8 in BIP-301, for the same reason. It is orthogonal to Appendix B, which
+changes no scriptPubKey.
+
+'''What is undecided''' is the number: two candidates have been named and only
+one can be used. This document keeps <code>OP_NOP5</code> until that is settled.
 
 ==Appendix B — Deterministic resolution in place of block rejection==
 
@@ -768,9 +903,15 @@ without discarding an otherwise valid block.
 | 11 || Transaction satisfying both the M5 and M6 structural rules || block invalid || classify by value delta; the normal M5/M6 rules then apply
 |}
 
-Items 4, 5, 6 and 7 correspond exactly to the four open questions the
-LayerTwo-Labs draft raises with "???"; this specification answers all four in
-the same direction.
+Items 5, 6 and 7 answer the three M4 rules the LayerTwo-Labs draft marks with
+<code>??? QUESTION</code>, in the direction those questions suggest; Appendix A,
+item 11 quotes each one and gives its location. Item 4 answers a fourth question
+the draft raises in the same spirit but marks differently
+(<code>/// Maybe it would make more sense to ignore proposals for inactive
+slots? ///</code>). The draft's remaining <code>???</code> — what happens to a
+treasury UTXO when its slot is overwritten — is '''not''' addressed here; it is
+a gap in the specification rather than a rejection that could be resolved
+deterministically. See Appendix A, item 12.
 
 The following are '''deliberately retained''' as block rejections, because for
 these the rejection is load-bearing rather than merely disambiguating: every

--- a/bip300-unified.mediawiki
+++ b/bip300-unified.mediawiki
@@ -1,0 +1,710 @@
+<pre>
+  BIP: 300
+  Layer: Consensus (soft fork)
+  Title: Hashrate Escrows (Consensus layer)
+  Authors: Paul Sztorc <truthcoin@gmail.com>
+           CryptAxe <cryptaxe@gmail.com>
+           Roberto Santacroce <roberto@santacroce.xyz>
+  Status: Draft
+  Type: Specification
+  Assigned: 2017-08-14
+  License: BSD-2-Clause
+  Discussion: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-May/014364.html
+</pre>
+
+''This document unifies the original BIP-300 draft with the LayerTwo-Labs
+protocol specification, and reconciles both against the reference
+implementation.''
+
+'''It proposes no behavioural change.''' Where the three sources agreed, the
+agreed rule is stated. Where they disagreed, the disagreement is resolved in
+favour of the reference implementation and recorded in Appendix A with its
+evidence. Where the implementation itself is ambiguous, that is said plainly
+rather than papered over.
+
+''A separate companion proposal,''
+[[#Companion proposal|Non-Invalidating Resolution for BIP-300/301]]'', proposes
+relaxing a number of the block-rejection rules below. None of it is incorporated
+here. This document is the baseline against which that proposal should be
+read.''
+
+==Abstract==
+
+BIP-300 enables a new type of L2, where "withdrawals" (the L2-to-L1 txns) are
+governed by proof-of-work — instead of a federation or fixed set of pubkeys.
+
+BIP-300 emphasizes slow, transparent, and auditable withdrawals that are easy
+for honest users to get right and hard for dishonest miners to abuse. The main
+design goal for BIP-300 is ''partitioning'' — users can ignore BIP-300 txns if
+they wish; it makes no difference to L1 if the user validates all, some, or none
+of them. The second design goal is ''security'' — users of the L2 should feel
+confident that, if the L2 network is paying a lot of fees, then miners will want
+to keep it around, and the withdrawals will therefore be processed accurately.
+
+==Motivation==
+
+BIP-300 allows Bitcoin to host L2 systems whose peg is secured by hashrate
+rather than by a trusted federation. See [http://www.drivechain.info/
+drivechain.info] for background and rationale.
+
+==Conventions==
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in RFC 2119.
+
+Three dispositions are used throughout, and are '''not''' interchangeable:
+
+* '''ignored''' — the message is not a BIP-300 message at all. It is treated as an ordinary script or transaction. No state changes. The block remains valid.
+* '''invalid (message)''' — the message parses as BIP-300 but violates a rule.
+* '''invalid (block)''' — the block MUST be rejected by BIP-300 enforcing nodes.
+
+Bitcoin nodes that do not enforce BIP-300 accept all of these blocks. BIP-300
+validity is strictly narrower than Bitcoin validity, which is what makes this a
+soft fork.
+
+==Constants==
+
+<pre>
+WITHDRAWAL_BUNDLE_MAX_AGE                  = 26300
+WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD      = 13150
+
+USED_SIDECHAIN_SLOT_PROPOSAL_MAX_AGE       = 26300
+USED_SIDECHAIN_SLOT_ACTIVATION_THRESHOLD   = 13150
+
+UNUSED_SIDECHAIN_SLOT_PROPOSAL_MAX_AGE     = 2016
+UNUSED_SIDECHAIN_SLOT_ACTIVATION_THRESHOLD = 1815
+</pre>
+
+All threshold comparisons are '''strict'''. A proposal or bundle succeeds when
+its vote count is '''greater than''' the threshold, i.e. a withdrawal bundle
+requires 13151 ACKs, not 13150. See Appendix A, item 6.
+
+Non-mainnet networks MAY substitute shorter values so that a full
+activation/withdrawal cycle is testable. Such values are consensus-relevant per
+network and MUST be agreed by all enforcing nodes on that network.
+
+==Message headers==
+
+<pre>
+M1: 0x6A 0xD5 0xE0 0xC4 0xAF
+M2: 0x6A 0xD6 0xE1 0xC5 0xDF     (see Appendix A, item 1 — UNRESOLVED)
+M3: 0x6A 0xD4 0x5A 0xA9 0x43
+M4: 0x6A 0xD7 0x7D 0x17 0x76
+</pre>
+
+M5 and M6 are not tagged messages; they are identified structurally, by their
+relationship to a treasury UTXO.
+
+==Specification==
+
+===Overview===
+
+BIP-300 consists of six messages:
+
+* M1. "Propose New Sidechain"  — coinbase output
+* M2. "ACK Proposal"           — coinbase output
+* M3. "Propose Bundle"         — coinbase output
+* M4. "ACK Bundle(s)"          — coinbase output
+* M5. Deposit (L1→L2)          — ordinary transaction
+* M6. Withdrawal (L2→L1)       — ordinary transaction
+
+Enforcing nodes maintain two logical databases:
+
+* D1. The Sidechain List
+* D2. The Withdrawal List
+
+===D1 — The Sidechain List===
+
+D1 holds one entry per sidechain slot. Slots are identified by a single unsigned
+byte <code>S</code> (0–255).
+
+{| class="wikitable"
+! Field !! Type !! Description
+|-
+| Slot number || uint8 || The slot's ID. Uniquely identifies each sidechain.
+|-
+| Description || bytes || Opaque sidechain description <code>D</code>. Not interpreted by BIP-300.
+|-
+| Active || bool || Whether this slot holds an activated sidechain.
+|-
+| Vote count || uint16 || ACKs accumulated by the proposal.
+|-
+| Proposal height || uint32 || Height of the block containing the M1.
+|-
+| Activation height || uint32 (optional) || Height at which the proposal activated.
+|-
+| CTIP outpoint || (txid, vout) || The treasury UTXO holding the sidechain's funds.
+|-
+| CTIP value || amount || Value of the treasury UTXO.
+|}
+
+The sidechain description <code>D</code> is an '''opaque byte array'''. Any
+internal structure is a convention between sidechain authors and their users and
+is '''not enforced''' by BIP-300. See Appendix A, item 8.
+
+===D2 — The Withdrawal List===
+
+Withdrawals are aggregated on L2 into "bundles". D2 holds the pending bundles
+per slot.
+
+{| class="wikitable"
+! Field !! Type !! Description
+|-
+| Slot number || uint8 || Links the bundle to a sidechain.
+|-
+| M6ID || uint256 || Blinded transaction ID of the withdrawal (see M6).
+|-
+| Vote count || uint16 || Miner upvotes. Starts at 1. Changes by at most 1 per block.
+|-
+| Proposal height || uint32 || Height of the block containing the M3.
+|}
+
+A bundle's <code>age</code> is <code>current_height - proposal_height</code>. A
+bundle is ''pending'' from the block that proposes it until it is either ''paid
+out'' (an M6 with the matching M6ID is included) or ''expired''
+(<code>age > WITHDRAWAL_BUNDLE_MAX_AGE</code>).
+
+Bundles maintain the following invariants:
+
+# The list has a canonical order: ascending by proposal height, then by coinbase output index within a block.
+# Vote counts change by at most 1 per block, in either direction, and saturate at zero.
+# A bundle whose vote count exceeds <code>WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD</code> is eligible for payout.
+# A bundle that expires is removed and pays nothing.
+
+===OP_DRIVECHAIN===
+
+This proposal adds a single new opcode. <code>OP_NOP5</code> (<code>0xB4</code>)
+is redefined as <code>OP_DRIVECHAIN</code> if and only if the entire script is
+exactly:
+
+<pre>
+OP_DRIVECHAIN OP_PUSHBYTES_1 <S> OP_TRUE
+</pre>
+
+which is exactly 4 bytes. <code>S</code> is the sidechain slot number, encoded as
+a raw unsigned byte. It is '''not''' a script number: it MUST NOT be encoded as
+<code>OP_1</code>..<code>OP_16</code> or any other push form, MUST NOT be
+sign-padded, and MUST be written as-is even for values above 127.
+
+The trailing <code>OP_TRUE</code> keeps the change a soft fork: without it, slot
+numbers 0 and 128 would cause the legacy script interpreter to fail.
+
+An output with this scriptPubKey is a '''treasury UTXO''' (historically "CTIP").
+When a treasury UTXO is spent, the additional rules of M5 or M6 MUST be
+enforced.
+
+'''There MUST never be two treasury UTXOs for the same sidechain slot.''' This
+is the central fund-safety invariant of BIP-300.
+
+===M1 — Propose Sidechain===
+
+====Encoding====
+
+<pre>
+OP_RETURN 0xD5 0xE0 0xC4 0xAF <S> <D>
+</pre>
+
+<code>S</code> is exactly 1 byte. <code>D</code> is all remaining bytes of the
+script, and is opaque. Its length is bounded only by Bitcoin's own rules.
+
+M1 MUST appear in an output of the coinbase transaction. An M1-shaped script in
+any non-coinbase transaction MUST be '''ignored'''. The output's
+<code>nValue</code> MUST be ignored.
+
+Define <code>proposal_id = sha256d(D)</code>.
+
+====Semantics====
+
+An M1 proposes that the sidechain described by <code>D</code> occupy slot
+<code>S</code>. If the slot is unused, the proposal is to '''activate'''. If the
+slot is used, the proposal is to '''overwrite''' the sidechain currently in it.
+After an overwrite, deposits to and withdrawals from the old sidechain are no
+longer recognised by BIP-300.
+
+====Validation====
+
+An M1 is '''ignored''' if it is not in a coinbase output.
+
+If a proposal with the same <code>(S, proposal_id)</code> already exists in D1
+from a previous block, the M1 MUST be '''ignored''' — it MUST NOT reset the
+existing vote count. Without this rule a miner could reset any proposal's
+progress at will.
+
+If a coinbase transaction contains two or more M1s with the same
+<code>(S, proposal_id)</code>, the block is '''invalid (block)'''.
+
+A coinbase MAY contain multiple M1s with the same <code>S</code> and different
+<code>D</code>, or with different <code>S</code> and the same <code>D</code>.
+
+''The original draft made any second M1 in a block invalidate it, regardless of
+content. The narrower rule above is the LayerTwo-Labs and implementation
+behaviour. See Appendix A, item 9.''
+
+Otherwise, a new D1 entry is created with <code>vote_count = 0</code>,
+<code>proposal_height = </code> the height of this block, and
+<code>active = false</code>.
+
+===M2 — ACK Sidechain Proposal===
+
+====Encoding====
+
+<pre>
+OP_RETURN 0xD6 0xE1 0xC5 0xDF <S> <proposal_id>
+</pre>
+
+A ''well-formed'' M2 script is exactly '''38 bytes''': the 5-byte header, 1 byte
+of <code>S</code>, and 32 bytes of <code>proposal_id</code>. Anything else MUST
+be '''ignored'''.
+
+''On the header byte see Appendix A, item 1 — this is an unresolved discrepancy
+requiring author input. On the length and slot byte see Appendix A, item 2.''
+
+====Semantics====
+
+An M2 is '''ignored''' if:
+
+* it is not within a coinbase output;
+* it is not well-formed;
+* <code>proposal_id</code> does not match any proposal created by an M1 in a previous block; or
+* <code>S</code> does not match the <code>sidechain_number</code> of that proposal.
+
+Otherwise the M2 is ''valid'' and the proposal's vote count is incremented by 1.
+
+If a coinbase transaction contains more than one well-formed M2 with the same
+<code>S</code>, the block is '''invalid (block)''', regardless of the
+<code>proposal_id</code> values.
+
+A proposal that receives no M2 in a block accrues an implicit "fail" for that
+block; <code>fails = age - vote_count</code>.
+
+====Activation====
+
+Let <code>age = current_height - proposal_height</code>.
+
+A proposal '''activates''' when:
+
+* the slot is '''unused''', <code>vote_count > UNUSED_SIDECHAIN_SLOT_ACTIVATION_THRESHOLD</code>, and <code>age <= UNUSED_SIDECHAIN_SLOT_PROPOSAL_MAX_AGE</code>; or
+* the slot is '''used''', <code>vote_count > USED_SIDECHAIN_SLOT_ACTIVATION_THRESHOLD</code>, and <code>age <= USED_SIDECHAIN_SLOT_PROPOSAL_MAX_AGE</code>.
+
+A proposal '''fails''' (and is discarded) when its age exceeds the relevant
+<code>MAX_AGE</code> without activating.
+
+The unused-slot threshold of 1815 out of 2016 blocks is a '''90%''' hashrate
+bar, not the 50% bar implied by the original draft. See Appendix A, item 3.
+
+===M3 — Propose Bundle===
+
+====Encoding====
+
+<pre>
+OP_RETURN 0xD4 0x5A 0xA9 0x43 <S> <M6ID>
+</pre>
+
+A ''well-formed'' M3 script is exactly 38 bytes: 5-byte header, 1 byte
+<code>S</code>, 32 bytes <code>M6ID</code>. Anything else MUST be '''ignored'''.
+
+====Validation====
+
+An M3 is '''ignored''' if it is not in a coinbase output or is not well-formed.
+
+The block is '''invalid (block)''' if any of the following hold:
+
+* the M3 names a sidechain slot that is not '''active''';
+* the named <code>M6ID</code> is '''already pending''' for slot <code>S</code>;
+* the coinbase contains two or more M3s with the same <code>(S, M6ID)</code>.
+
+A coinbase MAY contain multiple M3s with the same <code>S</code> and different
+<code>M6ID</code>, or with different <code>S</code> and the same
+<code>M6ID</code>.
+
+''The original draft additionally barred any bundle hash that had ever been paid
+out or rejected. That permanent blacklist is not retained; see Appendix A,
+item 4. It also barred a second M3 for the same slot in one block, which the
+LayerTwo-Labs draft and the implementation both permit.''
+
+An <code>M6ID</code> that is no longer pending — because it expired or was paid
+out — MAY be proposed again, starting a fresh vote count and expiry.
+
+Otherwise, a D2 entry is created with <code>vote_count = 1</code> and
+<code>proposal_height = </code> this block's height. Being proposed counts as
+the bundle's first upvote.
+
+===M4 — ACK Bundle(s)===
+
+====Encoding====
+
+<pre>
+OP_RETURN 0xD7 0x7D 0x17 0x76 <V> [A]
+</pre>
+
+<code>V</code> selects the version:
+
+{| class="wikitable"
+! V !! Name !! Body
+|-
+| 0x00 || <code>REPEAT_PREVIOUS</code> || none (script is exactly 6 bytes)
+|-
+| 0x01 || <code>VOTES_ONE_BYTE</code> || array of uint8
+|-
+| 0x02 || <code>VOTES_TWO_BYTE</code> || array of uint16, little-endian
+|-
+| 0x03 || <code>UPVOTE_LEADING_BY_50</code> || none (script is exactly 6 bytes)
+|}
+
+If a coinbase transaction contains more than one M4, the block is '''invalid
+(block)'''.
+
+If no M4 is present, the block abstains for every slot.
+
+====Slot indexing====
+
+Active slot numbers may be sparse, so array positions are '''not''' slot
+numbers. Enforcing nodes MUST:
+
+# Collect all active slot numbers into a vector <code>ASN</code>.
+# Sort <code>ASN</code> ascending.
+# Interpret <code>A[i]</code> as the vote for slot <code>ASN[i]</code>.
+
+====Bundle indexing====
+
+Within a slot, <code>A[i]</code> selects a bundle by position in the slot's
+pending list, sorted ascending by proposal height, ties broken by coinbase
+output index. Sentinel values:
+
+{| class="wikitable"
+! Meaning !! VOTES_ONE_BYTE !! VOTES_TWO_BYTE
+|-
+| ALARM || 0xFE || 0xFFFE
+|-
+| ABSTAIN || 0xFF || 0xFFFF
+|}
+
+====Vote semantics====
+
+For each slot <code>S_i</code> with vote <code>V_i</code>:
+
+* '''M6ID selected''' — that bundle gains 1 ACK; every other pending bundle in <code>S_i</code> loses 1.
+* '''ABSTAIN''' — no vote counts in <code>S_i</code> change.
+* '''ALARM''' — every pending bundle in <code>S_i</code> loses 1.
+
+Vote counts saturate at zero; they MUST NOT underflow.
+
+<code>REPEAT_PREVIOUS</code> casts the votes the previous block's M4 resolved
+to. Repeats chain transitively. Repeating an <code>UPVOTE_LEADING_BY_50</code>
+MUST NOT re-evaluate the leading-by-50 rule against current counts; it replays
+the resolved votes. If the previous block had no M4, or its M4 resolved to no
+votes, <code>REPEAT_PREVIOUS</code> casts no votes. A repeated upvote naming a
+bundle that is no longer pending casts no vote in that slot, and MUST NOT
+invalidate the block.
+
+<code>UPVOTE_LEADING_BY_50</code>, per slot: if some bundle leads every other
+bundle in that slot by at least 50 votes, upvote it (and downvote the rest);
+otherwise abstain in that slot.
+
+====Validation====
+
+The block is '''invalid (block)''' if any of the following hold:
+
+* the coinbase contains more than one M4;
+* <code>A</code> has more elements than <code>ASN</code>, i.e. the M4 votes in a slot that is not active;
+* an element of <code>A</code> selects a bundle index that does not exist in that slot's pending list;
+* the version is <code>VOTES_TWO_BYTE</code> and no element of <code>A</code> exceeds 253, i.e. <code>VOTES_ONE_BYTE</code> would have sufficed.
+
+''The LayerTwo-Labs draft raises all three of the latter rules as open questions.
+They are retained here as specified; the companion proposal argues for relaxing
+them.''
+
+====Mandatory payout====
+
+When a bundle's vote count exceeds
+<code>WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD</code>, the block in which this
+happens MUST include the corresponding M6. A block that does not is '''invalid
+(block)'''.
+
+===M5 — Deposit (L1 → L2)===
+
+====Semantics====
+
+An M5 moves coins from L1 into a sidechain's treasury. A transaction is an M5 if
+it creates a treasury UTXO for slot <code>S</code> whose value is '''greater
+than''' the value of the treasury UTXO it spent (or greater than zero, for the
+first ever deposit to that slot).
+
+====Structure====
+
+An M5 MUST have:
+
+# Exactly one treasury UTXO output for slot <code>S</code>, which becomes the new CTIP.
+# An address output immediately following the treasury output in <code>vout</code>: <code>OP_RETURN <A></code>, where <code>A</code> is an opaque sidechain address. Its <code>nValue</code> MUST be ignored.
+# An input spending the previous treasury UTXO for <code>S</code>, if one exists. If none exists, the previous treasury value is defined as 0.
+
+The slot number in the spent treasury UTXO MUST equal the slot number in the
+created one.
+
+<code>A</code> MUST be treated by enforcing nodes as a meaningless byte array.
+Its interpretation is the sidechain's business.
+
+A transaction that creates a larger treasury UTXO '''without''' the address
+output immediately following it is '''invalid (block)'''.
+
+''The original draft did not require the address output at all; the LayerTwo-Labs
+draft and the implementation do. See Appendix A, item 10.''
+
+====Deposit value recovery====
+
+The deposit amount is <code>V = T_new - T_old</code>. A treasury UTXO alone does
+not reveal <code>V</code>; recovering it requires the spent output's value.
+Enforcing nodes SHOULD index <code>(S, n) → (height, V, T, A)</code> so that
+deposits can be served without rescanning the chain, where <code>n</code> is a
+per-slot sequence number.
+
+Withdrawals (M6) MUST consume a sequence number, leaving a gap in the deposit
+sequence, so that the sequence records the full ordered history of treasury
+movements rather than deposits alone.
+
+===M6 — Withdrawal (L2 → L1)===
+
+====Semantics====
+
+An M6 moves coins out of a sidechain's treasury to L1 addresses. A transaction
+is an M6 if it spends a treasury UTXO and creates one whose value is '''less
+than''' the spent value.
+
+====Structure====
+
+An M6 MUST:
+
+# have '''exactly one input''', spending the treasury UTXO of slot <code>S</code>;
+# have the new treasury UTXO at '''<code>vout[0]</code>''', with the same slot number <code>S</code>;
+# have all withdrawal payout outputs at indices 1..n;
+# contain '''no''' additional <code>OP_DRIVECHAIN</code> outputs.
+
+Let <code>T_prev</code> be the spent treasury value, <code>T_new</code> the
+created treasury value, <code>P_total</code> the sum of all payout outputs, and
+<code>F_total</code> the transaction fee. Then:
+
+<pre>
+T_new = T_prev - P_total - F_total
+</pre>
+
+====M6ID and the blinded form====
+
+Bundles are voted on months before the treasury UTXO they will spend exists.
+Votes therefore commit to a '''blinded''' form of the transaction, not its final
+txid.
+
+<code>M6_blinded</code> differs from the final M6 in exactly two ways:
+
+# its <code>vin</code> is '''empty''';
+# <code>vout[0]</code> is a zero-value <code>OP_RETURN <F_total></code>, where <code>F_total</code> is a 64-bit unsigned integer encoded as '''8 bytes, big-endian''' — occupying the same index the treasury UTXO occupies in the final M6.
+
+<code>M6ID = txid(M6_blinded)</code>.
+
+Constructing the final M6 from the blinded form is therefore: replace
+<code>vout[0]</code> with the treasury output, and add the single treasury
+input. Nothing else changes, which is what lets the vote bind the payouts and
+the fee while leaving the treasury outpoint free.
+
+'''Both prior drafts specify this incorrectly and in different ways.''' See
+Appendix A, item 5. The layout above is the one the reference implementation
+uses and is the only one consistent with M6ID being stable across the treasury's
+lifetime.
+
+The blinded form MUST have a non-zero total payout.
+
+====Validation====
+
+An M6 is '''invalid (block)''' if any of the following hold:
+
+* its <code>M6ID</code> does not match a pending bundle for slot <code>S</code>;
+* that bundle's vote count does not exceed <code>WITHDRAWAL_BUNDLE_INCLUSION_THRESHOLD</code>;
+* that bundle's <code>age > WITHDRAWAL_BUNDLE_MAX_AGE</code>;
+* it has more or fewer than one input;
+* <code>vout[0]</code> is not a treasury UTXO for <code>S</code>;
+* it contains any further <code>OP_DRIVECHAIN</code> output;
+* the arithmetic above does not hold.
+
+===Transaction validation===
+
+A transaction that spends a treasury UTXO and does not create a new treasury
+UTXO for the same slot is '''invalid (block)'''.
+
+A transaction that creates a treasury UTXO for a slot whose treasury UTXO
+already exists, without spending it, is '''invalid (block)'''.
+
+A transaction that spends a treasury UTXO and creates a new one of '''equal'''
+value is '''invalid (block)''': it is neither a deposit nor a withdrawal.
+
+A transaction that appears to satisfy both the M5 and M6 structural rules is
+'''invalid (block)'''.
+
+M1–M4 never appear outside a coinbase transaction. An M1/M2/M3/M4-shaped
+OP_RETURN in a non-coinbase transaction MUST be '''ignored'''.
+
+The coinbase transaction never contains a treasury UTXO. A treasury-shaped
+output in a coinbase MUST be '''ignored'''.
+
+===Block validation===
+
+A block is '''invalid (block)''' if:
+
+* any non-coinbase transaction is invalid per the rules above;
+* it contains no transactions, i.e. has no coinbase;
+* any coinbase-message rule above is violated.
+
+==Rationale==
+
+===Why thresholds are strict===
+
+Both drafts describe the withdrawal threshold in prose as "reaches 13150 or
+greater", but the reference implementation compares strictly
+(<code>vote_count > threshold</code>). Since a bundle starts at 1 ACK on
+proposal and can gain at most 1 per block, the difference is one full block of
+hashrate approval on a 26300-block clock. This specification adopts the strict
+comparison and states it once, globally, rather than restating it per message.
+
+===Why the sidechain description is opaque===
+
+Consensus code should parse as little attacker-supplied structure as possible.
+The original draft's structured description added a parser to the consensus path
+whose only enforced property was that it parsed. Treating <code>D</code> as
+opaque and identifying proposals by <code>sha256d(D)</code> removes that surface
+without losing any enforced guarantee.
+
+===Why re-proposal is allowed===
+
+The original draft permanently blacklisted any bundle hash that was paid out or
+rejected. This is unnecessary for safety — a bundle that is paid out cannot be
+paid out twice, because the treasury UTXO it spent no longer exists — and it is
+harmful in practice, because a bundle that expires through miner apathy could
+never be retried, stranding those withdrawals forever. Allowing re-proposal with
+a fresh counter preserves safety and removes an unbounded-state requirement.
+
+==Backward compatibility==
+
+This soft fork can be deployed without modifying Bitcoin Core. Non-enforcing
+nodes accept every block that enforcing nodes accept, and additionally accept
+blocks that enforcing nodes reject.
+
+==Deployment==
+
+This BIP deploys when/if a majority of hashrate runs the enforcer client.
+
+Ideally a critical mass of users would also run it, which would strongly
+dissuade miners from de-activating it.
+
+==Reference implementation==
+
+[https://github.com/LayerTwo-Labs/bip300301_enforcer/ bip300301_enforcer], with
+the mempool/driver layer in
+[https://github.com/LayerTwo-Labs/cusf-enforcer-mempool/ cusf-enforcer-mempool].
+
+==Companion proposal==
+
+''Non-Invalidating Resolution for BIP-300/301'' proposes replacing a number of
+the block-rejection rules above with deterministic resolution — taking the first
+of a duplicate pair, treating an out-of-range vote as an abstain, and so on —
+and identifies which rejections are irreducible. '''None of it is incorporated
+in this document.''' It should be read as a delta against this baseline.
+
+Reviewers should note that every change it proposes ''relaxes'' validity, which
+between enforcer versions is a chain-splitting change rather than a soft fork,
+and therefore requires coordinated activation.
+
+==Appendix A — Reconciliation of prior drafts==
+
+Each item lists the disagreement, the resolution, and the evidence.
+
+'''1. M2 header byte — UNRESOLVED, requires author input.'''
+
+{| class="wikitable"
+! Source !! Value
+|-
+| Original BIP-300 || <code>D6 E1 C5 BF</code>
+|-
+| LayerTwo-Labs draft || <code>D6 E1 C5 BF</code>
+|-
+| Reference implementation || <code>D6 E1 C5 DF</code>
+|}
+
+The implementation disagrees with both specifications in the final byte. This
+document tentatively follows the implementation, since that is what is deployed
+and what any interoperating software must match today, but '''this must be
+confirmed by the authors before publication'''. If the specs are correct, the
+implementation has a wire-format bug; if the implementation is correct, both
+specs do. There is no way to tell from the documents alone.
+
+'''2. M2 length and slot byte.''' Original: 37 bytes, no slot number.
+LayerTwo-Labs: 38 bytes, with a 1-byte slot. Resolved in favour of 38 bytes; the
+implementation parses 1 byte of slot followed by 32 bytes of hash and rejects
+trailing data. Without the slot byte an M2 cannot be checked against the slot its
+proposal targets.
+
+'''3. Unused-slot activation threshold.''' Original: 1008 fails out of 2016
+blocks (50%). LayerTwo-Labs: 201 max fails, threshold 1815 (90%). Resolved in
+favour of 1815, per the implementation's <code>Thresholds::MAINNET</code>. This
+is a substantive policy difference, not an editorial one: it raises the bar for
+claiming an empty slot from a bare majority of hashrate to a supermajority.
+Reviewers should treat it as a deliberate change and confirm intent.
+
+'''4. Bundle re-proposal.''' Original: a bundle hash that was ever paid out or
+rejected is permanently barred. LayerTwo-Labs: only ''pending'' hashes are
+barred. Resolved in favour of the LayerTwo-Labs rule; see Rationale.
+
+'''5. M6 output layout.''' The two drafts and the implementation all differ:
+
+{| class="wikitable"
+! Source !! Treasury in M6 !! Fee OP_RETURN
+|-
+| Original BIP-300 || <code>vout[0]</code> || retained in the final M6 at <code>vout[1]</code>
+|-
+| LayerTwo-Labs || <code>vout[0]</code> in one paragraph, "last output" in two others || appended to the '''end''' of the blinded <code>vout</code>
+|-
+| Implementation || <code>vout[0]</code> || <code>vout[0]</code> of the '''blinded''' form only; replaced by the treasury output in the final M6
+|}
+
+The LayerTwo-Labs draft is internally inconsistent — it states index 0 when
+describing the M6 and "always the last output" when describing
+<code>m6_to_id</code>. Resolved in favour of the implementation: index 0 in both
+forms, with the fee OP_RETURN existing only in the blinded form. This is the
+only reading under which <code>M6ID</code> is computable before the treasury
+outpoint is known, which is the entire purpose of blinding.
+
+'''6. Threshold comparison.''' Original prose implies <code>>=</code>;
+LayerTwo-Labs and the implementation use <code>></code>. Resolved in favour of
+<code>></code>.
+
+'''7. M4 index bases.''' The original draft's worked example is internally
+inconsistent — it labels a message "version 00" (which carries no vote array)
+while showing a two-element array, and its "7th bundle / 4th bundle" prose does
+not match the bytes shown. The LayerTwo-Labs indexing algorithm (sorted active
+slots, chronologically sorted bundles, zero-based) is adopted, and the original
+example is dropped rather than repaired.
+
+'''8. Sidechain description structure.''' Original: structured (nSidechain,
+nVersion, title, description, hashID1, hashID2). LayerTwo-Labs and
+implementation: opaque bytes. Resolved in favour of opaque; see Rationale.
+
+'''9. Duplicate M1 and M3 scope.''' Original: a second M1 in a block, or a
+second M3 for the same slot, invalidates the block regardless of content.
+LayerTwo-Labs and implementation: only exact duplicates
+(<code>(S, proposal_id)</code> for M1, <code>(S, M6ID)</code> for M3) invalidate;
+differing content in the same slot is permitted. Resolved in favour of the
+narrower rule.
+
+'''10. M5 address output.''' Original: not required — an M5 is valid if it has
+one OP_DRIVECHAIN output and more coins than before. LayerTwo-Labs and
+implementation: an address <code>OP_RETURN</code> MUST immediately follow the
+treasury output. Resolved in favour of requiring it; without it a deposit cannot
+be attributed to any sidechain account.
+
+'''11. M4 open questions.''' The LayerTwo-Labs draft marks three of its own
+rules with "???" — the over-long vote array, the out-of-range bundle index, and
+the unnecessary two-byte encoding. All three are retained as specified here. The
+companion proposal argues for relaxing them; that argument is deliberately not
+made in this document.
+
+==Copyright==
+
+This BIP is licensed under the BSD 2-clause license.

--- a/bip300-unified.mediawiki
+++ b/bip300-unified.mediawiki
@@ -22,6 +22,11 @@ favour of the reference implementation and recorded in Appendix A with its
 evidence. Where the implementation itself is ambiguous, that is said plainly
 rather than papered over.
 
+Four appendix items are marked '''UNRESOLVED''' or '''OPEN DECISION'''. In each
+case the body states what the implementation does today, and the appendix states
+the question and what answering it would change. They are items 1, 9, 12 and 13,
+and they need author input before publication.
+
 ''A separate companion proposal,''
 [[bip300-unified-extended.mediawiki|Non-Invalidating Resolution for BIP-300/301]]'', proposes
 relaxing a number of the block-rejection rules below. None of it is incorporated
@@ -190,6 +195,12 @@ sign-padded, and MUST be written as-is even for values above 127.
 The trailing <code>OP_TRUE</code> keeps the change a soft fork: without it, slot
 numbers 0 and 128 would cause the legacy script interpreter to fail.
 
+''Moving <code>OP_DRIVECHAIN</code> off <code>OP_NOP5</code> to
+<code>OP_NOP8</code> or <code>OP_NOP9</code> has been proposed, so that BIP-300
+does not sit on a number a future Bitcoin Core soft fork might want. The choice
+of NOP is arbitrary and nothing else in this document depends on it. This is an
+open decision; see Appendix A, item 13.''
+
 An output with this scriptPubKey is a '''treasury UTXO''' (historically "CTIP").
 When a treasury UTXO is spent, the additional rules of M5 or M6 MUST be
 enforced.
@@ -222,6 +233,10 @@ slot is used, the proposal is to '''overwrite''' the sidechain currently in it.
 After an overwrite, deposits to and withdrawals from the old sidechain are no
 longer recognised by BIP-300.
 
+''What becomes of the overwritten sidechain's treasury UTXO — and therefore of
+the funds in it — is not answered by any of the three sources. See Appendix A,
+item 12; this is unresolved and requires author input.''
+
 ====Validation====
 
 An M1 is '''ignored''' if it is not in a coinbase output.
@@ -238,8 +253,9 @@ A coinbase MAY contain multiple M1s with the same <code>S</code> and different
 <code>D</code>, or with different <code>S</code> and the same <code>D</code>.
 
 ''The original draft made any second M1 in a block invalidate it, regardless of
-content. The narrower rule above is the LayerTwo-Labs and implementation
-behaviour. See Appendix A, item 9.''
+content — a deliberate one-proposal-per-block rate limit. The narrower rule
+above is the LayerTwo-Labs and implementation behaviour. Whether to restore the
+original limit is an open decision; see Appendix A, item 9.''
 
 Otherwise, a new D1 entry is created with <code>vote_count = 0</code>,
 <code>proposal_height = </code> the height of this block, and
@@ -320,8 +336,10 @@ A coinbase MAY contain multiple M3s with the same <code>S</code> and different
 
 ''The original draft additionally barred any bundle hash that had ever been paid
 out or rejected. That permanent blacklist is not retained; see Appendix A,
-item 4. It also barred a second M3 for the same slot in one block, which the
-LayerTwo-Labs draft and the implementation both permit.''
+item 4. It also barred a second M3 for the same slot in one block — the same
+rate limit it applied to M1 — which the LayerTwo-Labs draft and the
+implementation both permit. Whether to restore that limit is part of the open
+decision in Appendix A, item 9.''
 
 An <code>M6ID</code> that is no longer pending — because it expired or was paid
 out — MAY be proposed again, starting a fresh vote count and expiry.
@@ -479,6 +497,16 @@ An M6 MUST:
 # have the new treasury UTXO at '''<code>vout[0]</code>''', with the same slot number <code>S</code>;
 # have all withdrawal payout outputs at indices 1..n;
 # contain '''no''' additional <code>OP_DRIVECHAIN</code> outputs.
+
+<code>vout[0]</code> '''is''' the change output. Whatever treasury balance
+remains after the bundle's payouts and the transaction fee is returned to the
+same slot's treasury as a single UTXO, and that UTXO becomes the slot's new
+CTIP. It is the only <code>OP_DRIVECHAIN</code> output an M6 may contain: a
+withdrawal never creates a second one, and never leaves the slot without one.
+This is unchanged from the original design — all three sources return the change
+to the treasury at <code>vout[0]</code>, and their disagreement in Appendix A,
+item 5 is about the fee <code>OP_RETURN</code>, not about the change. Appendix A,
+item 10 does not bear on it either; that item concerns deposits only.
 
 Let <code>T_prev</code> be the spent treasury value, <code>T_new</code> the
 created treasury value, <code>P_total</code> the sum of all payout outputs, and
@@ -686,12 +714,36 @@ example is dropped rather than repaired.
 nVersion, title, description, hashID1, hashID2). LayerTwo-Labs and
 implementation: opaque bytes. Resolved in favour of opaque; see Rationale.
 
-'''9. Duplicate M1 and M3 scope.''' Original: a second M1 in a block, or a
-second M3 for the same slot, invalidates the block regardless of content.
-LayerTwo-Labs and implementation: only exact duplicates
-(<code>(S, proposal_id)</code> for M1, <code>(S, M6ID)</code> for M3) invalidate;
-differing content in the same slot is permitted. Resolved in favour of the
-narrower rule.
+'''9. Duplicate M1 and M3 scope — OPEN DECISION, resolved provisionally.'''
+Original: a second M1 in a block, or a second M3 for the same slot, invalidates
+the block regardless of content. LayerTwo-Labs and implementation: only exact
+duplicates (<code>(S, proposal_id)</code> for M1, <code>(S, M6ID)</code> for M3)
+invalidate; differing content in the same slot is permitted. The body above
+follows the implementation, as it does everywhere else.
+
+The narrowing was '''not''' a deliberate policy change. The original rule was a
+rate limit — one sidechain proposal per block — and it served two purposes:
+
+* '''Anti-spam and anti-blocking.''' One M1 per block means no miner can fill a coinbase with proposals, either to grief the slot table or to crowd out someone else's proposal. The same argument applies to M3 and bundle proposals.
+* '''Guarding miner attention.''' BIP-300 asks miners to form a judgement about each proposal. Metering proposals to one per block keeps that ask small, which was part of what made BIP-300 acceptable to miners at all.
+
+The current rule serves neither purpose. In review the authors restated the
+original intent: the one-per-block limit was deliberate, and the rapid
+activation of seven sidechains during testing was possible only because the
+limit is absent from the implementation.
+
+'''What is undecided''' is whether to restore it. Restoring it would mean:
+
+* an M1 is valid only if it is the '''only''' M1 in its coinbase; a second M1, of any content, makes the block '''invalid (block)''';
+* an M3 is valid only if it is the only M3 for its slot in that coinbase; and
+* the reference implementation changes to match — under a restored rule it is the implementation that is wrong, not this document.
+
+That last point is why the body is not simply rewritten. Every other item in
+this appendix resolves toward the implementation; this one would resolve against
+it, and making that change silently would misrepresent what this document is.
+The rule stated in the body is the implementation's rule. Once the authors
+confirm, the body changes and this item records the decision rather than the
+question.
 
 '''10. M5 address output.''' Original: not required — an M5 is valid if it has
 one OP_DRIVECHAIN output and more coins than before. LayerTwo-Labs and
@@ -699,11 +751,86 @@ implementation: an address <code>OP_RETURN</code> MUST immediately follow the
 treasury output. Resolved in favour of requiring it; without it a deposit cannot
 be attributed to any sidechain account.
 
-'''11. M4 open questions.''' The LayerTwo-Labs draft marks three of its own
-rules with "???" — the over-long vote array, the out-of-range bundle index, and
-the unnecessary two-byte encoding. All three are retained as specified here. The
-companion proposal argues for relaxing them; that argument is deliberately not
-made in this document.
+This item concerns '''deposits only'''. It does not bear on how a withdrawal
+returns its change: an M6 returns the remaining treasury balance to the same
+slot's treasury UTXO at <code>vout[0]</code> and creates no other
+<code>OP_DRIVECHAIN</code> output, exactly as in the original design. An M6 has
+no address output — its payouts are ordinary L1 outputs, already committed to by
+the <code>M6ID</code> the miners voted on.
+
+'''11. M4 open questions.''' The LayerTwo-Labs draft raises three of its own M4
+rules as open questions. They appear as inline <code>??? QUESTION</code>
+comments in the body of the draft rather than in any list of open issues, which
+is what makes them easy to miss. They are quoted in full below, with their
+location in <code>bip300.md</code> as of this repository's current revision:
+
+{| class="wikitable"
+! Rule questioned !! Location !! Text of the comment
+|-
+| A vote array longer than the active-slot vector invalidates the block || M4, slot indexing (line 401) || ''??? QUESTION: Does the above make sense? Would it be better to ignore the excess votes in <code>A</code>?''
+|-
+| An out-of-range bundle index invalidates the block || M4, <code>VOTES_ONE_BYTE</code> (line 441) || ''??? QUESTION: Would it make more sense to ignore the M4 with the index out of range error?''
+|-
+| Using <code>VOTES_TWO_BYTE</code> where one byte would do invalidates the block || M4, <code>VOTES_TWO_BYTE</code> (line 470) || ''??? QUESTION: Does it make sense to enforce this rule?''
+|}
+
+All three are retained as specified here. The companion proposal argues for
+relaxing them; that argument is deliberately not made in this document.
+
+Two further open questions are marked the same way elsewhere in the draft and
+are '''not''' M4 questions. The first asks whether an M3 for an inactive slot
+should be ignored rather than invalidate the block (M3 conditions, line 1070,
+marked <code>/// ... ///</code> rather than <code>???</code>); the companion
+proposal addresses it. The second is item 12 below, which nothing addresses.
+
+'''12. Treasury UTXO of an overwritten slot — UNRESOLVED, requires author
+input.''' The LayerTwo-Labs draft asks, at <code>bip300.md</code> line 773, at
+the end of the M5 section:
+
+''??? QUESTION: What happens to the treasury UTXO when a <code>used</code>
+sidechain slot is overwritten with a different sidechain? Does the same chain of
+treasury UTXOs continue?''
+
+Nothing answers it — not the original draft, not the LayerTwo-Labs draft, not
+this document, and not the companion proposal. M1 above says only that deposits
+to and withdrawals from the overwritten sidechain stop being recognised, which
+says nothing about the UTXO itself.
+
+The rules as written admit only one reading. A treasury UTXO is identified
+solely by the slot number in its <code>scriptPubKey</code>; a slot has at most
+one; and an M1 overwrite changes the slot's description without touching the
+UTXO set. So the same chain of treasury UTXOs does continue, and the incoming
+sidechain inherits the outgoing sidechain's balance — which the outgoing
+sidechain's users can no longer withdraw, since their pending bundles name a
+sidechain the slot no longer describes.
+
+Whether that is the intended outcome is a fund-safety decision, not an editorial
+one, and it MUST be settled before publication. Note also that the 90% bar of
+item 3 applies to claiming an ''empty'' slot; overwriting a ''used'' slot needs
+only <code>USED_SIDECHAIN_SLOT_ACTIVATION_THRESHOLD</code>, a bare majority of
+hashrate sustained over 26300 blocks.
+
+'''13. Opcode choice — OPEN DECISION.''' All three sources use
+<code>OP_NOP5</code> (<code>0xB4</code>), and the body above states it. In
+review it was proposed that <code>OP_DRIVECHAIN</code> move to
+<code>OP_NOP8</code> (<code>0xB7</code>) or <code>OP_NOP9</code>
+(<code>0xB8</code>), on two grounds:
+
+* The choice is arbitrary. Nothing in BIP-300 depends on which NOP is redefined.
+* <code>OP_NOP4</code> through <code>OP_NOP7</code> are the numbers a future Bitcoin Core soft fork is most likely to reach for first, <code>OP_NOP2</code> and <code>OP_NOP3</code> having already been taken by <code>OP_CHECKLOCKTIMEVERIFY</code> and <code>OP_CHECKSEQUENCEVERIFY</code>. A collision with a real Core deployment would be far more costly to BIP-300 than choosing a different number now.
+
+The probability of such a collision is small. The cost of moving is currently
+near zero: BIP-300 is not deployed on mainnet, so no treasury UTXO exists whose
+<code>scriptPubKey</code> would have to change.
+
+A move touches the <code>OP_DRIVECHAIN</code> definition above, every treasury
+UTXO <code>scriptPubKey</code>, the reference implementation, and every
+sidechain implementation that constructs deposits or withdrawals. It does not
+touch M1–M4, which are <code>OP_RETURN</code> messages and carry no opcode, nor
+M7 and M8 in BIP-301, for the same reason.
+
+'''What is undecided''' is the number: two candidates have been named and only
+one can be used. This document keeps <code>OP_NOP5</code> until that is settled.
 
 ==Copyright==
 

--- a/bip300-unified.mediawiki
+++ b/bip300-unified.mediawiki
@@ -23,7 +23,7 @@ evidence. Where the implementation itself is ambiguous, that is said plainly
 rather than papered over.
 
 ''A separate companion proposal,''
-[[#Companion proposal|Non-Invalidating Resolution for BIP-300/301]]'', proposes
+[[bip300-unified-extended.mediawiki|Non-Invalidating Resolution for BIP-300/301]]'', proposes
 relaxing a number of the block-rejection rules below. None of it is incorporated
 here. This document is the baseline against which that proposal should be
 read.''

--- a/bip301-unified-extended.mediawiki
+++ b/bip301-unified-extended.mediawiki
@@ -20,6 +20,14 @@ would eliminate every block-rejection rule in this BIP. The baseline variant —
 <code>bip301-unified.mediawiki</code> — carries the same reconciliation without
 that argument, and is the document to read first.
 
+'''One caveat, and it is a large one.''' The M8 wire format is provisional: BMM
+bidding and accepting are being reworked, and the M8 encoding in both prior
+drafts describes a superseded design in which a BMM request was a distinct
+transaction type. The encoding stated here is the one enforced today. Appendix A,
+item 7 sets out which parts of the M8 section a redesign may change and which
+four rules it must preserve — and why Appendix B's conclusion does not depend on
+the outcome.
+
 ==Abstract==
 
 Blind Merged Mining (BMM) allows SHA-256d miners to collect transaction fee
@@ -86,12 +94,20 @@ she must let Simon control the side:block.
 ==Message headers==
 
 <pre>
-M7 (BMM Accept):  0x6A 0xD1 0x61 0x73 0x68
-M8 (BMM Request): 0x6A 0x00 0xBF 0x00
+M7 (BMM Accept):  0x6A <push> 0xD1 0x61 0x73 0x68 ...
+M8 (BMM Request): 0x6A 0x44   0x00 0xBF 0x00 ...
 </pre>
 
-Note that the M8 header is '''3''' bytes, not 4 like every other message in the
-BIP-300/301 family. See Appendix A, item 5.
+Both are <code>OP_RETURN</code> outputs, but they are '''not''' parsed the same
+way, and the difference is easy to miss:
+
+* '''M7''' is parsed as script ''instructions'' — <code>OP_RETURN</code> followed by a single push whose data begins with the 4-byte tag <code>D1 61 73 68</code>. The push opcode is not constrained, so any valid push encoding of the payload is accepted. Every BIP-300 coinbase message is parsed this way too.
+* '''M8''' is matched against a fixed ''byte prefix'' — the script MUST begin literally <code>6A 44</code>, that is <code>OP_RETURN OP_PUSHBYTES_68</code>, followed by the 3-byte tag <code>00 BF 00</code>. The push opcode is pinned by the fixed message length, and an <code>OP_PUSHDATA1</code> encoding of the same 68 payload bytes does '''not''' parse.
+
+So the M8 tag is 3 bytes where every other tag in the BIP-300/301 family is 4,
+and the M8 script is byte-exact where the others are not. Both are artefacts of
+an earlier design rather than requirements of BIP-301; see Appendix A, items 5
+and 7.
 
 ''The original draft named these "BMM Accept" and "BMM Request" without
 numbering. The M7/M8 numbering from the LayerTwo-Labs draft is adopted here; it
@@ -149,6 +165,15 @@ a side:block without an explicit paid request.
 
 ===M8 — BMM Request===
 
+'''The encoding in this section is provisional; the validation rules are not.'''
+BMM bidding and accepting are being reworked, and the wire format below descends
+from a design in which a BMM request was a distinct transaction type rather than
+an ordinary transaction carrying an <code>OP_RETURN</code>. What follows is what
+the reference implementation enforces today. Appendix A, item 7 separates the
+parts a redesign may change from the parts it must preserve; the Validation
+subsection below is the second kind, and Appendix B explains why those rules
+resist the treatment this variant applies to BIP-300's.
+
 ====Semantics====
 
 An M8 is an offer of a reward to mainchain miners for including an M7 with the
@@ -160,28 +185,47 @@ output paying an address the miner controls, or simply the transaction fee.
 
 Only one M8 may be accepted per mainchain block per sidechain slot.
 
-====Encoding====
+====Encoding (provisional)====
 
 An M8 MUST be an ordinary Bitcoin transaction. While pending, it sits in the
 mempool unmined.
 
-The output at '''index 0''' MUST have this scriptPubKey:
+The output at '''index 0''' MUST have this scriptPubKey, as exactly 70 bytes:
 
 <pre>
-OP_RETURN 0x00 0xBF 0x00 <S> <H> <P>
+OP_RETURN OP_PUSHBYTES_68 0x00 0xBF 0x00 <S> <H> <P>
+    6A          44          <-- 68 payload bytes ------>
 </pre>
 
 where <code>S</code> is 1 byte (slot), <code>H</code> is 32 bytes (side:block
 hash), and <code>P</code> is 32 bytes (the previous mainchain block hash). The
 output's <code>nValue</code> MUST be ignored.
 
-Enforcing nodes MUST NOT interpret any part of the M8 transaction other than
-this output. In particular, how Simon pays Mary is outside this specification.
+The push opcode is part of the match, not incidental: the implementation
+compares the leading bytes <code>6A 44</code> literally and then requires the
+script to end after <code>P</code>. A payload push encoded as
+<code>OP_PUSHDATA1</code>, or any trailing byte, fails to parse and the output
+is not an M8 at all. This is stricter than M7 and than every BIP-300 coinbase
+message, which are parsed as script instructions; see Message headers above.
+
+Only the output at index 0 is examined. Enforcing nodes MUST NOT interpret any
+other part of the M8 transaction. In particular, how Simon pays Mary is outside
+this specification.
+
+Note that the reference wallet also sets an <code>nLockTime</code> on the M8
+transactions it builds, and its RPC takes a block height. Neither is consensus
+relevant: nothing in validation reads them. Both are residue of the earlier
+design, in which the request's expiry was carried by the transaction rather than
+by the <code>P</code> field.
 
 ''The original draft did not fix the output index; the LayerTwo-Labs draft fixes
-it at 0, as does the implementation. Adopted.''
+it at 0, as does the implementation. Adopted as current behaviour, not as a
+settled design point — see Appendix A, items 3 and 7.''
 
 ====Validation====
+
+Unlike the encoding above, these rules do '''not''' depend on how a BMM request
+is carried on the wire, and a redesign of the encoding MUST preserve all three.
 
 A mainchain block is '''invalid''' if any of the following hold:
 
@@ -189,14 +233,19 @@ A mainchain block is '''invalid''' if any of the following hold:
 # It contains more than one M8 for the same slot <code>S</code>.
 # It contains an M8 whose <code>P</code> is not the hash of this block's immediate parent.
 
-Rule 3 confines an M8 to the single block it was written for. Without it, a
-miner could hoard old requests and mine them later, collecting payment for
-side:blocks that can no longer be connected.
+Rule 2 is what makes BMM trustless rather than reputational; see Rationale. Rule
+3 confines an M8 to the single block it was written for. Without it, a miner
+could hoard old requests and mine them later, collecting payment for side:blocks
+that can no longer be connected.
+
+These three rules, together with the one-M7-per-slot rule above, are the whole
+of BIP-301's consensus content. Everything else in this section is encoding.
 
 ''The LayerTwo-Labs draft omits rule 3 entirely, although the reference
 implementation enforces it (<code>HandleM8::BmmRequestExpired</code>). Its
 omission appears to be an oversight rather than an intended relaxation; it is
-restored here. See Appendix A, item 2.''
+restored here, and the authors have confirmed it as intended. See Appendix A,
+item 2.''
 
 '''All three rules are retained as hard rejections.''' Appendix B explains why
 this family, unlike most of BIP-300's rejection rules, cannot be converted to
@@ -270,25 +319,75 @@ driver layer in
 '''1. Message naming.''' Original: "BMM Accept" / "BMM Request". LayerTwo-Labs:
 M7 / M8. Adopted M7/M8, with both names given.
 
-'''2. The <code>prevMainBlock</code> rule.''' Present in the original draft
-("The 32-bytes of prevMainBlock must match the previous main:blockhash"), absent
-from the LayerTwo-Labs draft's validation rules, present in the implementation.
-Restored.
+'''2. The <code>prevMainBlock</code> rule — CONFIRMED.''' Present in the
+original draft ("The 32-bytes of prevMainBlock must match the previous
+main:blockhash"), absent from the LayerTwo-Labs draft's validation rules,
+present in the implementation. Restored, and confirmed by the authors in review
+as intended.
 
-'''3. M8 output index.''' Unspecified in the original; index 0 in the
-LayerTwo-Labs draft and the implementation. Adopted.
+It is in the code: <code>handle_m8</code> compares the request's
+<code>prev_mainchain_block_hash</code> against the connecting block's
+<code>header.prev_blockhash</code> and returns
+<code>HandleM8::BmmRequestExpired</code> on mismatch
+(<code>lib/validator/task/mod.rs</code>). It is now also in the specification,
+as rule 3 of the M8 validation list.
 
-'''4. One-M8-per-slot as a block rule.''' The LayerTwo-Labs draft states this in
-its semantics section but does not restate it among its validation rules, where
-only the missing-M7 and duplicate-M7 rules appear. The implementation enforces
-it as a block-level rule (<code>ConnectBlock::MultipleBmmRequests</code>). It is
-stated explicitly as rule 2 here.
+'''3. M8 output index — PROVISIONAL.''' Unspecified in the original; index 0 in
+the LayerTwo-Labs draft and in the implementation, which reads
+<code>transaction.output.first()</code> and parses only that output
+(<code>parse_m8_tx</code>, <code>lib/messages.rs</code>). Recorded as what is
+enforced today.
 
-'''5. Header length.''' The M8 header is '''3''' bytes
-(<code>00 BF 00</code>), not 4 like the BIP-300 messages and M7. Both drafts
-agree on this, and the implementation matches
-(<code>M8BmmRequest::TAG: [u8; 3]</code>). It is preserved for compatibility but
-noted here because it is a standing trap for implementers.
+The authors note in review that BMM bidding and accepting are a work in
+progress, and that the documentation should follow whatever the new mechanism
+does. Index 0 is therefore '''not''' a settled design point. See item 7.
+
+'''4. One-M8-per-slot as a block rule — CONFIRMED, and load-bearing.''' The
+LayerTwo-Labs draft states this in its semantics section but does not restate it
+among its validation rules, where only the missing-M7 and duplicate-M7 rules
+appear. The implementation enforces it as a block-level rule
+(<code>ConnectBlock::MultipleBmmRequests</code>, raised in the transaction loop
+of <code>connect_block</code>). It is stated explicitly as rule 2 in the M8
+validation list.
+
+The authors confirm that one M8 per sidechain per block MUST be enforced, and
+that this survives the encoding rework of item 7 unchanged. It is the rule that
+makes BMM trustless rather than reputational; see Rationale, and Appendix B for
+why it is the one class of rule this variant does not convert.
+
+'''5. Header length — a fossil, not a design choice.''' The M8 tag is '''3'''
+bytes (<code>00 BF 00</code>), not 4 like the BIP-300 messages and M7. Both
+drafts agree, and the implementation matches
+(<code>M8BmmRequest::TAG: [u8; 3]</code>).
+
+An earlier revision of this document presented that as a quirk preserved for
+compatibility and left it there. The authors have since supplied the
+explanation: the 3-byte tag, and the shape of the M8 encoding generally, come
+from a design in which a BMM request was a '''distinct transaction type'''
+carrying a critical-data field — not an ordinary transaction with an
+<code>OP_RETURN</code> output. In that design these bytes were not an
+<code>OP_RETURN</code> header at all, which is why they do not follow the
+convention the <code>OP_RETURN</code> messages follow.
+
+The lineage is still visible in the implementation. The wallet RPC that builds
+an M8 is <code>CreateBmmCriticalDataTransaction</code>, taking
+<code>critical_hash</code>, <code>prev_bytes</code> and <code>height</code>
+(<code>lib/server/wallet/grpc.rs</code>); <code>M8BmmRequest</code>'s
+<code>sidechain_block_hash</code> field is commented "Also called H* or critical
+hash, critical data hash, hash critical" (<code>lib/messages.rs</code>); and the
+wallet still sets an <code>nLockTime</code> that no validation rule reads.
+
+A second artefact of the same origin: the M8 parser matches the '''fixed byte
+prefix''' <code>6A 44 00 BF 00</code> rather than parsing script instructions,
+so the push opcode is pinned and an <code>OP_PUSHDATA1</code> encoding of the
+same 68 payload bytes is rejected. M7 and every BIP-300 coinbase message are
+parsed as instructions and accept any valid push encoding. Nothing in BIP-301
+requires that asymmetry.
+
+Neither the 3-byte tag nor the byte-exact prefix should be read as a constraint
+on the replacement encoding. Both are documented because they describe what is
+deployed today, and because an implementer working from the deployed format
+needs to know they are traps rather than intentions.
 
 '''6. Scope of "BMM Request must match a BMM Accept".''' The original draft
 frames this as a rule making the ''transaction'' invalid; the LayerTwo-Labs
@@ -296,6 +395,40 @@ draft and the implementation frame it as making the ''block'' invalid. Resolved
 in favour of block invalidity — a transaction-level rule would be unenforceable,
 since a non-enforcing node would accept the transaction regardless. Appendix B
 turns on exactly this point.
+
+'''7. The M8 encoding is under revision — OPEN.''' The authors report that BMM
+bidding and accepting are a work in progress, and that the M8 material in the
+prior drafts describes the deprecated special-transaction design rather than
+whatever replaces it. This document therefore specifies the current
+implementation, and separates what a redesign may change from what it must
+preserve:
+
+{| class="wikitable"
+! Must survive any redesign !! May change freely
+|-
+| An M8 is valid only if the same block's coinbase carries a matching M7 — same <code>S</code>, same <code>H</code> || Whether the request is carried in an output, and at what index
+|-
+| At most one M8 per slot per mainchain block (item 4) || The tag bytes, their length, and the push encoding (item 5)
+|-
+| An M8 binds to exactly one parent block, so a request cannot be hoarded and mined later (item 2) || Whether that binding is expressed as a <code>P</code> field, an <code>nLockTime</code>, or otherwise
+|-
+| Enforcing nodes interpret nothing else in the transaction; how the miner is paid stays out of consensus || Whether the request is an on-chain transaction at all — see Appendix B
+|}
+
+The left column is the whole of BIP-301's consensus content, and each entry has
+an argument behind it in the Rationale, in item 2, or in Appendix B. The right
+column is encoding, and has none. A reviewer of the new mechanism should check
+it against the left column and then replace the M8 encoding section wholesale,
+rather than patching the format described here.
+
+Two consequences worth stating. First, the M7 side is largely unaffected: an
+accept must appear in the main:coinbase whatever the request looks like, so the
+one-M7-per-slot rule and the M7 encoding are not in scope for this rework.
+Second, Appendix B's conclusion is unchanged by it. Appendix B turns on the M8
+fee reaching the miner on-chain regardless of what an enforcing node decides —
+an argument about ''where the payment goes'', not about how the request is
+encoded. Re-encoding the request removes none of the rejections; only moving the
+payment off-chain does.
 
 ==Appendix B — Why BIP-301's rejections are retained, and what would remove them==
 

--- a/bip301-unified-extended.mediawiki
+++ b/bip301-unified-extended.mediawiki
@@ -1,0 +1,365 @@
+<pre>
+  BIP: 301
+  Layer: Consensus (soft fork)
+  Title: Blind Merged Mining (Consensus layer)
+  Authors: Paul Sztorc <truthcoin@gmail.com>
+           CryptAxe <cryptaxe@gmail.com>
+           Roberto Santacroce <roberto@santacroce.xyz>
+  Status: Draft
+  Type: Specification
+  Assigned: 2019-07-23
+  License: BSD-2-Clause
+</pre>
+
+''This document unifies the original BIP-301 draft with the LayerTwo-Labs
+protocol specification, and reconciles both against the reference
+implementation. Differences are listed in Appendix A.''
+
+'''This is the extended variant.''' Its Appendix B argues that off-chain BMM
+would eliminate every block-rejection rule in this BIP. The baseline variant —
+<code>bip301-unified.mediawiki</code> — carries the same reconciliation without
+that argument, and is the document to read first.
+
+==Abstract==
+
+Blind Merged Mining (BMM) allows SHA-256d miners to collect transaction fee
+revenue from other blockchains without running any software for those chains
+(i.e. without "looking" at them — hence "blind").
+
+Block assembly for the other chain is done by that chain's users. They choose
+the block and its transactions; simultaneously they bid on L1 for the exclusive
+right to be the creator of that block. BIP-301 ensures that L1 miners can accept
+only one bid per L2 per block, rather than accepting all of them.
+
+==Motivation==
+
+Traditional merged mining has two drawbacks:
+
+# Miners must run a full node of the other chain, i.e. non-Bitcoin software which may be buggy.
+# Miners are paid on the other chain, in that chain's currency.
+
+BIP-301 removes both. The miner runs nothing extra and is paid in BTC on L1.
+
+==Notation==
+
+We prefix otherwise ambiguous words with <code>side:</code> and
+<code>main:</code>. We name all sidechain users "Simon" and all mainchain miners
+"Mary".
+
+Each candidate side:block is identified by its side:blockhash <code>h*</code>.
+Even if the rest of the block is identical, different Simons produce different
+side:coinbases and therefore different <code>h*</code>.
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" are to be interpreted as
+described in RFC 2119.
+
+==Worked example==
+
+A side:block contains 20,000 transactions each paying $0.10, so it is worth
+$2,000 in fees. The sidechain's coinbase pays that $2,000 to Simon. Simon does
+no hashing; he makes one L1 transaction paying $1,999 to Mary. Mary ends up with
+essentially all the fee revenue without touching the sidechain.
+
+{| class="wikitable"
+|-
+! colspan="3" | Upon finding a side:block worth $2000
+|-
+! Item !! Mary (L1 miner) !! Simon (sidechain user)
+|-
+| Runs a sidechain node? || No || Yes
+|-
+| Share of hashing || 100% || 0%
+|-
+| Collected on L2 || $0 || $2000
+|-
+| Paid out on L1 || $0 || $1999
+|-
+| Received on L1 || $1999 || $0
+|-
+| Net || +$1999 || +$1
+|}
+
+BIP-301 makes this division of labour trustless: if Mary takes Simon's money,
+she must let Simon control the side:block.
+
+==Message headers==
+
+<pre>
+M7 (BMM Accept):  0x6A 0xD1 0x61 0x73 0x68
+M8 (BMM Request): 0x6A 0x00 0xBF 0x00
+</pre>
+
+Note that the M8 header is '''3''' bytes, not 4 like every other message in the
+BIP-300/301 family. See Appendix A, item 5.
+
+''The original draft named these "BMM Accept" and "BMM Request" without
+numbering. The M7/M8 numbering from the LayerTwo-Labs draft is adopted here; it
+is what the reference implementation and the surrounding BIP-300 message
+sequence use. Both names are given at each definition so the two literatures
+remain cross-readable.''
+
+==Specification==
+
+BIP-301 consists of two messages:
+
+* '''M7 — BMM Accept.''' A coinbase output on L1 containing <code>h*</code>. Mary may endorse at most one <code>h*</code> per sidechain slot.
+* '''M8 — BMM Request.''' An ordinary L1 transaction in which Simon offers to pay Mary if and only if Mary's block contains Simon's <code>h*</code>.
+
+Mary controls the main:coinbase, so she selects which <code>h*</code> to
+endorse. Her selection determines which side:block is found, and which M8 she
+can collect.
+
+===M7 — BMM Accept===
+
+====Semantics====
+
+An M7 naming slot <code>S</code> and side:blockhash <code>H</code> means that
+the side:block with hash <code>H</code> is now blind merge mined. If it also
+passes the sidechain's own validation rules, sidechain nodes may connect it.
+
+There MUST be at most one M7 per mainchain block per sidechain slot.
+
+====Encoding====
+
+An M7 MUST be encoded as an output of the coinbase transaction:
+
+<pre>
+OP_RETURN 0xD1 0x61 0x73 0x68 <S> <H>
+</pre>
+
+<code>S</code> is 1 byte; <code>H</code> is 32 bytes. The output's
+<code>nValue</code> MUST be ignored.
+
+If no M7 outputs are present, no BMM requests were accepted, and Mary collects
+nothing from M8s.
+
+Mary and Simon MAY be the same party. In that case only M7s are needed; M8s
+exist to make the arrangement trustless between distinct parties.
+
+====Validation====
+
+A mainchain block containing more than one M7 for the same slot <code>S</code>
+is '''invalid'''.
+
+''This rule is retained as a hard rejection. See Appendix B.''
+
+A block MAY contain an M7 with no corresponding M8: a miner may blind merge mine
+a side:block without an explicit paid request.
+
+===M8 — BMM Request===
+
+====Semantics====
+
+An M8 is an offer of a reward to mainchain miners for including an M7 with the
+matching <code>S</code> and <code>H</code>. The miner can only collect by
+including that M7.
+
+The form of the reward is not specified here. In practice it is an ordinary
+output paying an address the miner controls, or simply the transaction fee.
+
+Only one M8 may be accepted per mainchain block per sidechain slot.
+
+====Encoding====
+
+An M8 MUST be an ordinary Bitcoin transaction. While pending, it sits in the
+mempool unmined.
+
+The output at '''index 0''' MUST have this scriptPubKey:
+
+<pre>
+OP_RETURN 0x00 0xBF 0x00 <S> <H> <P>
+</pre>
+
+where <code>S</code> is 1 byte (slot), <code>H</code> is 32 bytes (side:block
+hash), and <code>P</code> is 32 bytes (the previous mainchain block hash). The
+output's <code>nValue</code> MUST be ignored.
+
+Enforcing nodes MUST NOT interpret any part of the M8 transaction other than
+this output. In particular, how Simon pays Mary is outside this specification.
+
+''The original draft did not fix the output index; the LayerTwo-Labs draft fixes
+it at 0, as does the implementation. Adopted.''
+
+====Validation====
+
+A mainchain block is '''invalid''' if any of the following hold:
+
+# It contains an M8 with no corresponding M7 in the same block. "Corresponding" means both <code>S</code> and <code>H</code> match.
+# It contains more than one M8 for the same slot <code>S</code>.
+# It contains an M8 whose <code>P</code> is not the hash of this block's immediate parent.
+
+Rule 3 confines an M8 to the single block it was written for. Without it, a
+miner could hoard old requests and mine them later, collecting payment for
+side:blocks that can no longer be connected.
+
+''The LayerTwo-Labs draft omits rule 3 entirely, although the reference
+implementation enforces it (<code>HandleM8::BmmRequestExpired</code>). Its
+omission appears to be an oversight rather than an intended relaxation; it is
+restored here. See Appendix A, item 2.''
+
+'''All three rules are retained as hard rejections.''' Appendix B explains why
+this family, unlike most of BIP-300's rejection rules, cannot be converted to
+deterministic selection.
+
+===Interaction with BIP-300===
+
+BIP-301 does not move coins. An M8 has no effect on any treasury UTXO, and an M7
+has no effect on the sidechain list or withdrawal list. The two BIPs share only
+the slot numbering: <code>S</code> in an M7 or M8 refers to a slot in BIP-300's
+D1, and messages naming an inactive slot have no BMM meaning.
+
+==Rationale==
+
+===Why one accept per slot per block===
+
+If a miner could accept several BMM requests for the same sidechain in one
+block, she could collect fees from several Simons while only one side:block can
+possibly be connected. Every other Simon pays for nothing. The LayerTwo-Labs
+draft states the concern directly:
+
+> If a miner is allowed to accept multiple BMM requests in the same block for
+> the same sidechain, then the miner can collect fees for sidechain blocks that
+> were not actually connected to the sidechain, which is undesirable.
+
+The one-per-slot rule makes that outcome impossible rather than merely
+detectable, and it is the reason BMM is trustless rather than reputational.
+Appendix B explains why this is expressed as block invalidity rather than as a
+rule for picking a winner among several requests.
+
+===Why payment terms are unspecified===
+
+Fixing the payment mechanism in consensus would constrain the market
+unnecessarily. Leaving it open allows the offer to be an ordinary fee, an
+explicit output, or an off-chain payment.
+
+===Lightning-based requests===
+
+BMM requests MAY be made over Lightning: Simon pays Mary conditionally
+off-chain, and Mary includes the M7 to claim. BMM ''accepts'' cannot be moved
+off-chain, since they must appear in the main:coinbase.
+
+One method is described at
+[https://www.drivechain.info/media/bmm-note/bmm-lightning/ drivechain.info].
+No formal specification of it exists, and this BIP does not provide one.
+
+Off-chain requests also sidestep the fee-harvesting concern discussed in
+Appendix B entirely, because no on-chain fee is paid by a losing bidder. Where
+BMM volume is high, this is the recommended arrangement.
+
+==Backward compatibility==
+
+This soft fork can be deployed without modifying Bitcoin Core. Non-enforcing
+nodes accept every block enforcing nodes accept, and additionally accept blocks
+enforcing nodes reject.
+
+==Deployment==
+
+This BIP deploys when/if a majority of hashrate runs the enforcer client, in
+tandem with BIP-300.
+
+==Reference implementation==
+
+[https://github.com/LayerTwo-Labs/bip300301_enforcer/ bip300301_enforcer]
+(<code>handle_m8</code> in <code>lib/validator/task/mod.rs</code>), with the
+driver layer in
+[https://github.com/LayerTwo-Labs/cusf-enforcer-mempool/ cusf-enforcer-mempool].
+
+==Appendix A — Reconciliation of prior drafts==
+
+'''1. Message naming.''' Original: "BMM Accept" / "BMM Request". LayerTwo-Labs:
+M7 / M8. Adopted M7/M8, with both names given.
+
+'''2. The <code>prevMainBlock</code> rule.''' Present in the original draft
+("The 32-bytes of prevMainBlock must match the previous main:blockhash"), absent
+from the LayerTwo-Labs draft's validation rules, present in the implementation.
+Restored.
+
+'''3. M8 output index.''' Unspecified in the original; index 0 in the
+LayerTwo-Labs draft and the implementation. Adopted.
+
+'''4. One-M8-per-slot as a block rule.''' The LayerTwo-Labs draft states this in
+its semantics section but does not restate it among its validation rules, where
+only the missing-M7 and duplicate-M7 rules appear. The implementation enforces
+it as a block-level rule (<code>ConnectBlock::MultipleBmmRequests</code>). It is
+stated explicitly as rule 2 here.
+
+'''5. Header length.''' The M8 header is '''3''' bytes
+(<code>00 BF 00</code>), not 4 like the BIP-300 messages and M7. Both drafts
+agree on this, and the implementation matches
+(<code>M8BmmRequest::TAG: [u8; 3]</code>). It is preserved for compatibility but
+noted here because it is a standing trap for implementers.
+
+'''6. Scope of "BMM Request must match a BMM Accept".''' The original draft
+frames this as a rule making the ''transaction'' invalid; the LayerTwo-Labs
+draft and the implementation frame it as making the ''block'' invalid. Resolved
+in favour of block invalidity — a transaction-level rule would be unenforceable,
+since a non-enforcing node would accept the transaction regardless. Appendix B
+turns on exactly this point.
+
+==Appendix B — Why BIP-301's rejections are retained, and what would remove them==
+
+A companion analysis proposes replacing many of BIP-300's block-rejection rules
+with deterministic resolution — for example, resolving duplicate coinbase
+messages by taking the first rather than rejecting the block. Every rule in
+BIP-301 is deliberately '''excluded''' from that treatment.
+
+The reason is economic, not technical. Deterministic selection is perfectly
+implementable here: "accept the first M8 for each slot, or the one paying the
+highest fee, and ignore the rest" is a pure function of the block. But an M8 is
+an ordinary Bitcoin transaction, and '''its fee is paid to the miner whether or
+not the enforcer counts it as a BMM request'''. Under a selection rule, a miner
+who includes ten M8s for one slot keeps ten fees while only one side:block is
+connected. That is precisely the outcome the one-per-slot rule exists to
+prevent, and selection would make it profitable rather than fatal.
+
+The same argument applies to duplicate M7s (which enable the same harvest) and
+to stale M8s (which let a miner mine hoarded requests for side:blocks that can
+no longer connect).
+
+Block rejection works here because it is the only response that reaches the
+miner's ''entire'' revenue for the block, including the fees she would otherwise
+harvest. Any response that leaves those fees in her hands leaves the attack
+profitable.
+
+===The exception: off-chain requests===
+
+The argument above depends entirely on the M8 fee being paid '''on-chain'''.
+Remove that and it collapses — in the useful direction.
+
+Under Lightning-based BMM (see Rationale), Simon pays Mary conditionally
+off-chain and Mary claims by including the M7. A losing bidder pays '''nothing
+on-chain'''. There is then no fee to harvest, and every rejection rule in this
+BIP loses its purpose:
+
+{| class="wikitable"
+! Rule !! Why it exists !! Under off-chain requests
+|-
+| One M8 per slot || miner harvests N fees || no on-chain fee to harvest
+|-
+| One M7 per slot || same harvest via M7 || becomes a well-formedness question
+|-
+| M8 requires matching M7 || fee taken without endorsement || payment is conditional on the M7
+|-
+| <code>P</code> must be the parent hash || hoarded requests mined late || the offer expires off-chain
+|}
+
+Note what becomes of the one-M7-per-slot rule specifically: with no on-chain M8,
+it stops being a theft guard and becomes a plain question of which side:block
+the miner endorsed. That is resolvable deterministically — '''take the M7 at the
+lowest output index''' — exactly like the duplicate-message cases in BIP-300
+Appendix B.
+
+Specifying off-chain BMM is therefore the single highest-leverage change
+available to this BIP: it eliminates all of its block-rejection rules at once,
+and it is the only path by which BIP-301 reaches zero rejections. The mechanism
+is sketched in the original draft and formalised nowhere. Until it is specified,
+implemented, and in use, the rules above MUST be retained; dropping them earlier
+re-opens the harvest.
+
+A fuller treatment is in the companion document, ''Non-Invalidating Resolution
+for BIP-300/301'', §5.1.
+
+==Copyright==
+
+This BIP is licensed under the BSD 2-clause license.

--- a/bip301-unified.mediawiki
+++ b/bip301-unified.mediawiki
@@ -1,0 +1,310 @@
+<pre>
+  BIP: 301
+  Layer: Consensus (soft fork)
+  Title: Blind Merged Mining (Consensus layer)
+  Authors: Paul Sztorc <truthcoin@gmail.com>
+           CryptAxe <cryptaxe@gmail.com>
+           Roberto Santacroce <roberto@santacroce.xyz>
+  Status: Draft
+  Type: Specification
+  Assigned: 2019-07-23
+  License: BSD-2-Clause
+</pre>
+
+''This document unifies the original BIP-301 draft with the LayerTwo-Labs
+protocol specification, and reconciles both against the reference
+implementation.''
+
+'''It proposes no behavioural change.''' Where the three sources agreed, the
+agreed rule is stated. Where they disagreed, the disagreement is resolved in
+favour of the reference implementation and recorded in Appendix A with its
+evidence.
+
+''A separate companion proposal,''
+[[#Companion proposal|Non-Invalidating Resolution for BIP-300/301]]'', argues
+that every block-rejection rule in this BIP could be eliminated by moving BMM
+payment off-chain. None of it is incorporated here. This document is the
+baseline against which that proposal should be read.''
+
+==Abstract==
+
+Blind Merged Mining (BMM) allows SHA-256d miners to collect transaction fee
+revenue from other blockchains without running any software for those chains
+(i.e. without "looking" at them — hence "blind").
+
+Block assembly for the other chain is done by that chain's users. They choose
+the block and its transactions; simultaneously they bid on L1 for the exclusive
+right to be the creator of that block. BIP-301 ensures that L1 miners can accept
+only one bid per L2 per block, rather than accepting all of them.
+
+==Motivation==
+
+Traditional merged mining has two drawbacks:
+
+# Miners must run a full node of the other chain, i.e. non-Bitcoin software which may be buggy.
+# Miners are paid on the other chain, in that chain's currency.
+
+BIP-301 removes both. The miner runs nothing extra and is paid in BTC on L1.
+
+==Notation==
+
+We prefix otherwise ambiguous words with <code>side:</code> and
+<code>main:</code>. We name all sidechain users "Simon" and all mainchain miners
+"Mary".
+
+Each candidate side:block is identified by its side:blockhash <code>h*</code>.
+Even if the rest of the block is identical, different Simons produce different
+side:coinbases and therefore different <code>h*</code>.
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" are to be interpreted as
+described in RFC 2119.
+
+==Worked example==
+
+A side:block contains 20,000 transactions each paying $0.10, so it is worth
+$2,000 in fees. The sidechain's coinbase pays that $2,000 to Simon. Simon does
+no hashing; he makes one L1 transaction paying $1,999 to Mary. Mary ends up with
+essentially all the fee revenue without touching the sidechain.
+
+{| class="wikitable"
+|-
+! colspan="3" | Upon finding a side:block worth $2000
+|-
+! Item !! Mary (L1 miner) !! Simon (sidechain user)
+|-
+| Runs a sidechain node? || No || Yes
+|-
+| Share of hashing || 100% || 0%
+|-
+| Collected on L2 || $0 || $2000
+|-
+| Paid out on L1 || $0 || $1999
+|-
+| Received on L1 || $1999 || $0
+|-
+| Net || +$1999 || +$1
+|}
+
+BIP-301 makes this division of labour trustless: if Mary takes Simon's money,
+she must let Simon control the side:block.
+
+==Message headers==
+
+<pre>
+M7 (BMM Accept):  0x6A 0xD1 0x61 0x73 0x68
+M8 (BMM Request): 0x6A 0x00 0xBF 0x00
+</pre>
+
+''The original draft named these "BMM Accept" and "BMM Request" without
+numbering. The M7/M8 numbering from the LayerTwo-Labs draft is adopted here; it
+is what the reference implementation and the surrounding BIP-300 message
+sequence use. Both names are given at each definition so the two literatures
+remain cross-readable.''
+
+Note that the M8 header is '''3''' bytes, not 4 like every other message in the
+BIP-300/301 family. See Appendix A, item 5.
+
+==Specification==
+
+BIP-301 consists of two messages:
+
+* '''M7 — BMM Accept.''' A coinbase output on L1 containing <code>h*</code>. Mary may endorse at most one <code>h*</code> per sidechain slot.
+* '''M8 — BMM Request.''' An ordinary L1 transaction in which Simon offers to pay Mary if and only if Mary's block contains Simon's <code>h*</code>.
+
+Mary controls the main:coinbase, so she selects which <code>h*</code> to
+endorse. Her selection determines which side:block is found, and which M8 she
+can collect.
+
+===M7 — BMM Accept===
+
+====Semantics====
+
+An M7 naming slot <code>S</code> and side:blockhash <code>H</code> means that
+the side:block with hash <code>H</code> is now blind merge mined. If it also
+passes the sidechain's own validation rules, sidechain nodes may connect it.
+
+There MUST be at most one M7 per mainchain block per sidechain slot.
+
+====Encoding====
+
+An M7 MUST be encoded as an output of the coinbase transaction:
+
+<pre>
+OP_RETURN 0xD1 0x61 0x73 0x68 <S> <H>
+</pre>
+
+<code>S</code> is 1 byte; <code>H</code> is 32 bytes. The output's
+<code>nValue</code> MUST be ignored.
+
+If no M7 outputs are present, no BMM requests were accepted, and Mary collects
+nothing from M8s.
+
+Mary and Simon MAY be the same party. In that case only M7s are needed; M8s
+exist to make the arrangement trustless between distinct parties.
+
+====Validation====
+
+A mainchain block containing more than one M7 for the same slot <code>S</code>
+is '''invalid'''.
+
+A block MAY contain an M7 with no corresponding M8: a miner may blind merge mine
+a side:block without an explicit paid request.
+
+===M8 — BMM Request===
+
+====Semantics====
+
+An M8 is an offer of a reward to mainchain miners for including an M7 with the
+matching <code>S</code> and <code>H</code>. The miner can only collect by
+including that M7.
+
+The form of the reward is not specified here. In practice it is an ordinary
+output paying an address the miner controls, or simply the transaction fee.
+
+Only one M8 may be accepted per mainchain block per sidechain slot.
+
+====Encoding====
+
+An M8 MUST be an ordinary Bitcoin transaction. While pending, it sits in the
+mempool unmined.
+
+The output at '''index 0''' MUST have this scriptPubKey:
+
+<pre>
+OP_RETURN 0x00 0xBF 0x00 <S> <H> <P>
+</pre>
+
+where <code>S</code> is 1 byte (slot), <code>H</code> is 32 bytes (side:block
+hash), and <code>P</code> is 32 bytes (the previous mainchain block hash). The
+output's <code>nValue</code> MUST be ignored.
+
+Enforcing nodes MUST NOT interpret any part of the M8 transaction other than
+this output. In particular, how Simon pays Mary is outside this specification.
+
+''The original draft did not fix the output index; the LayerTwo-Labs draft fixes
+it at 0, as does the implementation. Adopted. See Appendix A, item 3.''
+
+====Validation====
+
+A mainchain block is '''invalid''' if any of the following hold:
+
+# It contains an M8 with no corresponding M7 in the same block. "Corresponding" means both <code>S</code> and <code>H</code> match.
+# It contains more than one M8 for the same slot <code>S</code>.
+# It contains an M8 whose <code>P</code> is not the hash of this block's immediate parent.
+
+Rule 3 confines an M8 to the single block it was written for. Without it, a
+miner could hoard old requests and mine them later, collecting payment for
+side:blocks that can no longer be connected.
+
+''The LayerTwo-Labs draft omits rule 3 entirely, although the reference
+implementation enforces it (<code>HandleM8::BmmRequestExpired</code>). Its
+omission appears to be an oversight rather than an intended relaxation; it is
+restored here. See Appendix A, item 2.''
+
+===Interaction with BIP-300===
+
+BIP-301 does not move coins. An M8 has no effect on any treasury UTXO, and an M7
+has no effect on the sidechain list or withdrawal list. The two BIPs share only
+the slot numbering: <code>S</code> in an M7 or M8 refers to a slot in BIP-300's
+D1, and messages naming an inactive slot have no BMM meaning.
+
+==Rationale==
+
+===Why one accept per slot per block===
+
+If a miner could accept several BMM requests for the same sidechain in one
+block, she could collect fees from several Simons while only one side:block can
+possibly be connected. Every other Simon pays for nothing. The LayerTwo-Labs
+draft states the concern directly:
+
+> If a miner is allowed to accept multiple BMM requests in the same block for
+> the same sidechain, then the miner can collect fees for sidechain blocks that
+> were not actually connected to the sidechain, which is undesirable.
+
+The one-per-slot rule makes that outcome impossible rather than merely
+detectable, and it is the reason BMM is trustless rather than reputational.
+
+Note that this is why the rule is expressed as ''block invalidity'' rather than
+as a rule for picking a winner among several requests. An M8 is an ordinary
+Bitcoin transaction whose fee reaches the miner through Bitcoin's own rules,
+regardless of what an enforcing node decides about it. Only rejecting the whole
+block reaches that revenue.
+
+===Why payment terms are unspecified===
+
+Fixing the payment mechanism in consensus would constrain the market
+unnecessarily. Leaving it open allows the offer to be an ordinary fee, an
+explicit output, or an off-chain payment.
+
+===Lightning-based requests===
+
+BMM requests MAY be made over Lightning: Simon pays Mary conditionally
+off-chain, and Mary includes the M7 to claim. BMM ''accepts'' cannot be moved
+off-chain, since they must appear in the main:coinbase.
+
+One method is described at
+[https://www.drivechain.info/media/bmm-note/bmm-lightning/ drivechain.info].
+No formal specification of it exists, and this BIP does not provide one.
+
+==Backward compatibility==
+
+This soft fork can be deployed without modifying Bitcoin Core. Non-enforcing
+nodes accept every block enforcing nodes accept, and additionally accept blocks
+enforcing nodes reject.
+
+==Deployment==
+
+This BIP deploys when/if a majority of hashrate runs the enforcer client, in
+tandem with BIP-300.
+
+==Reference implementation==
+
+[https://github.com/LayerTwo-Labs/bip300301_enforcer/ bip300301_enforcer]
+(<code>handle_m8</code> in <code>lib/validator/task/mod.rs</code>), with the
+driver layer in
+[https://github.com/LayerTwo-Labs/cusf-enforcer-mempool/ cusf-enforcer-mempool].
+
+==Companion proposal==
+
+''Non-Invalidating Resolution for BIP-300/301'' observes that all three
+validation rules above, and the one-M7-per-slot rule, exist solely because BMM
+payment is made on-chain — and that specifying Lightning-based requests would
+remove the need for every one of them. '''That argument is not made in this
+document''', which specifies the protocol as it stands. It should be read as a
+delta against this baseline.
+
+==Appendix A — Reconciliation of prior drafts==
+
+'''1. Message naming.''' Original: "BMM Accept" / "BMM Request". LayerTwo-Labs:
+M7 / M8. Adopted M7/M8, with both names given.
+
+'''2. The <code>prevMainBlock</code> rule.''' Present in the original draft
+("The 32-bytes of prevMainBlock must match the previous main:blockhash"), absent
+from the LayerTwo-Labs draft's validation rules, present in the implementation.
+Restored.
+
+'''3. M8 output index.''' Unspecified in the original; index 0 in the
+LayerTwo-Labs draft and the implementation. Adopted.
+
+'''4. One-M8-per-slot as a block rule.''' The LayerTwo-Labs draft states this in
+its semantics section but does not restate it among its validation rules, where
+only the missing-M7 and duplicate-M7 rules appear. The implementation enforces
+it as a block-level rule (<code>ConnectBlock::MultipleBmmRequests</code>). It is
+stated explicitly as rule 2 here.
+
+'''5. Header length.''' The M8 header is '''3''' bytes
+(<code>00 BF 00</code>), not 4 like the BIP-300 messages and M7. Both drafts
+agree on this, and the implementation matches
+(<code>M8BmmRequest::TAG: [u8; 3]</code>). It is preserved for compatibility but
+noted here because it is a standing trap for implementers.
+
+'''6. Scope of "BMM Request must match a BMM Accept".''' The original draft
+frames this as a rule making the ''transaction'' invalid; the LayerTwo-Labs
+draft and the implementation frame it as making the ''block'' invalid. Resolved
+in favour of block invalidity — a transaction-level rule would be unenforceable,
+since a non-enforcing node would accept the transaction regardless.
+
+==Copyright==
+
+This BIP is licensed under the BSD 2-clause license.

--- a/bip301-unified.mediawiki
+++ b/bip301-unified.mediawiki
@@ -20,6 +20,13 @@ agreed rule is stated. Where they disagreed, the disagreement is resolved in
 favour of the reference implementation and recorded in Appendix A with its
 evidence.
 
+'''One caveat, and it is a large one.''' The M8 wire format is provisional: BMM
+bidding and accepting are being reworked, and the M8 encoding in both prior
+drafts describes a superseded design in which a BMM request was a distinct
+transaction type. The encoding stated here is the one enforced today. Appendix A,
+item 7 sets out which parts of the M8 section a redesign may change and which
+four rules it must preserve.
+
 ''A separate companion proposal,''
 [[bip301-unified-extended.mediawiki|Non-Invalidating Resolution for BIP-300/301]]'', argues
 that every block-rejection rule in this BIP could be eliminated by moving BMM
@@ -92,8 +99,8 @@ she must let Simon control the side:block.
 ==Message headers==
 
 <pre>
-M7 (BMM Accept):  0x6A 0xD1 0x61 0x73 0x68
-M8 (BMM Request): 0x6A 0x00 0xBF 0x00
+M7 (BMM Accept):  0x6A <push> 0xD1 0x61 0x73 0x68 ...
+M8 (BMM Request): 0x6A 0x44   0x00 0xBF 0x00 ...
 </pre>
 
 ''The original draft named these "BMM Accept" and "BMM Request" without
@@ -102,8 +109,16 @@ is what the reference implementation and the surrounding BIP-300 message
 sequence use. Both names are given at each definition so the two literatures
 remain cross-readable.''
 
-Note that the M8 header is '''3''' bytes, not 4 like every other message in the
-BIP-300/301 family. See Appendix A, item 5.
+Both are <code>OP_RETURN</code> outputs, but they are '''not''' parsed the same
+way, and the difference is easy to miss:
+
+* '''M7''' is parsed as script ''instructions'' — <code>OP_RETURN</code> followed by a single push whose data begins with the 4-byte tag <code>D1 61 73 68</code>. The push opcode is not constrained, so any valid push encoding of the payload is accepted. Every BIP-300 coinbase message is parsed this way too.
+* '''M8''' is matched against a fixed ''byte prefix'' — the script MUST begin literally <code>6A 44</code>, that is <code>OP_RETURN OP_PUSHBYTES_68</code>, followed by the 3-byte tag <code>00 BF 00</code>. The push opcode is pinned by the fixed message length, and an <code>OP_PUSHDATA1</code> encoding of the same 68 payload bytes does '''not''' parse.
+
+So the M8 tag is 3 bytes where every other tag in the BIP-300/301 family is 4,
+and the M8 script is byte-exact where the others are not. Both are artefacts of
+an earlier design rather than requirements of BIP-301; see Appendix A, items 5
+and 7.
 
 ==Specification==
 
@@ -153,6 +168,14 @@ a side:block without an explicit paid request.
 
 ===M8 — BMM Request===
 
+'''The encoding in this section is provisional; the validation rules are not.'''
+BMM bidding and accepting are being reworked, and the wire format below descends
+from a design in which a BMM request was a distinct transaction type rather than
+an ordinary transaction carrying an <code>OP_RETURN</code>. What follows is what
+the reference implementation enforces today. Appendix A, item 7 separates the
+parts a redesign may change from the parts it must preserve; the Validation
+subsection below is the second kind.
+
 ====Semantics====
 
 An M8 is an offer of a reward to mainchain miners for including an M7 with the
@@ -164,28 +187,47 @@ output paying an address the miner controls, or simply the transaction fee.
 
 Only one M8 may be accepted per mainchain block per sidechain slot.
 
-====Encoding====
+====Encoding (provisional)====
 
 An M8 MUST be an ordinary Bitcoin transaction. While pending, it sits in the
 mempool unmined.
 
-The output at '''index 0''' MUST have this scriptPubKey:
+The output at '''index 0''' MUST have this scriptPubKey, as exactly 70 bytes:
 
 <pre>
-OP_RETURN 0x00 0xBF 0x00 <S> <H> <P>
+OP_RETURN OP_PUSHBYTES_68 0x00 0xBF 0x00 <S> <H> <P>
+    6A          44          <-- 68 payload bytes ------>
 </pre>
 
 where <code>S</code> is 1 byte (slot), <code>H</code> is 32 bytes (side:block
 hash), and <code>P</code> is 32 bytes (the previous mainchain block hash). The
 output's <code>nValue</code> MUST be ignored.
 
-Enforcing nodes MUST NOT interpret any part of the M8 transaction other than
-this output. In particular, how Simon pays Mary is outside this specification.
+The push opcode is part of the match, not incidental: the implementation
+compares the leading bytes <code>6A 44</code> literally and then requires the
+script to end after <code>P</code>. A payload push encoded as
+<code>OP_PUSHDATA1</code>, or any trailing byte, fails to parse and the output
+is not an M8 at all. This is stricter than M7 and than every BIP-300 coinbase
+message, which are parsed as script instructions; see Message headers above.
+
+Only the output at index 0 is examined. Enforcing nodes MUST NOT interpret any
+other part of the M8 transaction. In particular, how Simon pays Mary is outside
+this specification.
+
+Note that the reference wallet also sets an <code>nLockTime</code> on the M8
+transactions it builds, and its RPC takes a block height. Neither is consensus
+relevant: nothing in validation reads them. Both are residue of the earlier
+design, in which the request's expiry was carried by the transaction rather than
+by the <code>P</code> field.
 
 ''The original draft did not fix the output index; the LayerTwo-Labs draft fixes
-it at 0, as does the implementation. Adopted. See Appendix A, item 3.''
+it at 0, as does the implementation. Adopted as current behaviour, not as a
+settled design point — see Appendix A, items 3 and 7.''
 
 ====Validation====
+
+Unlike the encoding above, these rules do '''not''' depend on how a BMM request
+is carried on the wire, and a redesign of the encoding MUST preserve all three.
 
 A mainchain block is '''invalid''' if any of the following hold:
 
@@ -193,14 +235,19 @@ A mainchain block is '''invalid''' if any of the following hold:
 # It contains more than one M8 for the same slot <code>S</code>.
 # It contains an M8 whose <code>P</code> is not the hash of this block's immediate parent.
 
-Rule 3 confines an M8 to the single block it was written for. Without it, a
-miner could hoard old requests and mine them later, collecting payment for
-side:blocks that can no longer be connected.
+Rule 2 is what makes BMM trustless rather than reputational; see Rationale. Rule
+3 confines an M8 to the single block it was written for. Without it, a miner
+could hoard old requests and mine them later, collecting payment for side:blocks
+that can no longer be connected.
+
+These three rules, together with the one-M7-per-slot rule above, are the whole
+of BIP-301's consensus content. Everything else in this section is encoding.
 
 ''The LayerTwo-Labs draft omits rule 3 entirely, although the reference
 implementation enforces it (<code>HandleM8::BmmRequestExpired</code>). Its
 omission appears to be an oversight rather than an intended relaxation; it is
-restored here. See Appendix A, item 2.''
+restored here, and the authors have confirmed it as intended. See Appendix A,
+item 2.''
 
 ===Interaction with BIP-300===
 
@@ -279,31 +326,113 @@ delta against this baseline.
 '''1. Message naming.''' Original: "BMM Accept" / "BMM Request". LayerTwo-Labs:
 M7 / M8. Adopted M7/M8, with both names given.
 
-'''2. The <code>prevMainBlock</code> rule.''' Present in the original draft
-("The 32-bytes of prevMainBlock must match the previous main:blockhash"), absent
-from the LayerTwo-Labs draft's validation rules, present in the implementation.
-Restored.
+'''2. The <code>prevMainBlock</code> rule — CONFIRMED.''' Present in the
+original draft ("The 32-bytes of prevMainBlock must match the previous
+main:blockhash"), absent from the LayerTwo-Labs draft's validation rules,
+present in the implementation. Restored, and confirmed by the authors in review
+as intended.
 
-'''3. M8 output index.''' Unspecified in the original; index 0 in the
-LayerTwo-Labs draft and the implementation. Adopted.
+It is in the code: <code>handle_m8</code> compares the request's
+<code>prev_mainchain_block_hash</code> against the connecting block's
+<code>header.prev_blockhash</code> and returns
+<code>HandleM8::BmmRequestExpired</code> on mismatch
+(<code>lib/validator/task/mod.rs</code>). It is now also in the specification,
+as rule 3 of the M8 validation list.
 
-'''4. One-M8-per-slot as a block rule.''' The LayerTwo-Labs draft states this in
-its semantics section but does not restate it among its validation rules, where
-only the missing-M7 and duplicate-M7 rules appear. The implementation enforces
-it as a block-level rule (<code>ConnectBlock::MultipleBmmRequests</code>). It is
-stated explicitly as rule 2 here.
+'''3. M8 output index — PROVISIONAL.''' Unspecified in the original; index 0 in
+the LayerTwo-Labs draft and in the implementation, which reads
+<code>transaction.output.first()</code> and parses only that output
+(<code>parse_m8_tx</code>, <code>lib/messages.rs</code>). Recorded as what is
+enforced today.
 
-'''5. Header length.''' The M8 header is '''3''' bytes
-(<code>00 BF 00</code>), not 4 like the BIP-300 messages and M7. Both drafts
-agree on this, and the implementation matches
-(<code>M8BmmRequest::TAG: [u8; 3]</code>). It is preserved for compatibility but
-noted here because it is a standing trap for implementers.
+The authors note in review that BMM bidding and accepting are a work in
+progress, and that the documentation should follow whatever the new mechanism
+does. Index 0 is therefore '''not''' a settled design point. See item 7.
+
+'''4. One-M8-per-slot as a block rule — CONFIRMED, and load-bearing.''' The
+LayerTwo-Labs draft states this in its semantics section but does not restate it
+among its validation rules, where only the missing-M7 and duplicate-M7 rules
+appear. The implementation enforces it as a block-level rule
+(<code>ConnectBlock::MultipleBmmRequests</code>, raised in the transaction loop
+of <code>connect_block</code>). It is stated explicitly as rule 2 in the M8
+validation list.
+
+The authors confirm that one M8 per sidechain per block MUST be enforced, and
+that this survives the encoding rework of item 7 unchanged. It is the rule that
+makes BMM trustless rather than reputational; see Rationale.
+
+'''5. Header length — a fossil, not a design choice.''' The M8 tag is '''3'''
+bytes (<code>00 BF 00</code>), not 4 like the BIP-300 messages and M7. Both
+drafts agree, and the implementation matches
+(<code>M8BmmRequest::TAG: [u8; 3]</code>).
+
+An earlier revision of this document presented that as a quirk preserved for
+compatibility and left it there. The authors have since supplied the
+explanation: the 3-byte tag, and the shape of the M8 encoding generally, come
+from a design in which a BMM request was a '''distinct transaction type'''
+carrying a critical-data field — not an ordinary transaction with an
+<code>OP_RETURN</code> output. In that design these bytes were not an
+<code>OP_RETURN</code> header at all, which is why they do not follow the
+convention the <code>OP_RETURN</code> messages follow.
+
+The lineage is still visible in the implementation. The wallet RPC that builds
+an M8 is <code>CreateBmmCriticalDataTransaction</code>, taking
+<code>critical_hash</code>, <code>prev_bytes</code> and <code>height</code>
+(<code>lib/server/wallet/grpc.rs</code>); <code>M8BmmRequest</code>'s
+<code>sidechain_block_hash</code> field is commented "Also called H* or critical
+hash, critical data hash, hash critical" (<code>lib/messages.rs</code>); and the
+wallet still sets an <code>nLockTime</code> that no validation rule reads.
+
+A second artefact of the same origin: the M8 parser matches the '''fixed byte
+prefix''' <code>6A 44 00 BF 00</code> rather than parsing script instructions,
+so the push opcode is pinned and an <code>OP_PUSHDATA1</code> encoding of the
+same 68 payload bytes is rejected. M7 and every BIP-300 coinbase message are
+parsed as instructions and accept any valid push encoding. Nothing in BIP-301
+requires that asymmetry.
+
+Neither the 3-byte tag nor the byte-exact prefix should be read as a constraint
+on the replacement encoding. Both are documented because they describe what is
+deployed today, and because an implementer working from the deployed format
+needs to know they are traps rather than intentions.
 
 '''6. Scope of "BMM Request must match a BMM Accept".''' The original draft
 frames this as a rule making the ''transaction'' invalid; the LayerTwo-Labs
 draft and the implementation frame it as making the ''block'' invalid. Resolved
 in favour of block invalidity — a transaction-level rule would be unenforceable,
 since a non-enforcing node would accept the transaction regardless.
+
+'''7. The M8 encoding is under revision — OPEN.''' The authors report that BMM
+bidding and accepting are a work in progress, and that the M8 material in the
+prior drafts describes the deprecated special-transaction design rather than
+whatever replaces it. This document therefore specifies the current
+implementation, and separates what a redesign may change from what it must
+preserve:
+
+{| class="wikitable"
+! Must survive any redesign !! May change freely
+|-
+| An M8 is valid only if the same block's coinbase carries a matching M7 — same <code>S</code>, same <code>H</code> || Whether the request is carried in an output, and at what index
+|-
+| At most one M8 per slot per mainchain block (item 4) || The tag bytes, their length, and the push encoding (item 5)
+|-
+| An M8 binds to exactly one parent block, so a request cannot be hoarded and mined later (item 2) || Whether that binding is expressed as a <code>P</code> field, an <code>nLockTime</code>, or otherwise
+|-
+| Enforcing nodes interpret nothing else in the transaction; how the miner is paid stays out of consensus || Whether the request is an on-chain transaction at all — see the companion proposal on off-chain requests
+|}
+
+The left column is the whole of BIP-301's consensus content, and each entry has
+an argument behind it in the Rationale or in item 2. The right column is
+encoding, and has none. A reviewer of the new mechanism should check it against
+the left column and then replace the M8 encoding section wholesale, rather than
+patching the format described here.
+
+Two consequences worth stating. First, the M7 side is largely unaffected: an
+accept must appear in the main:coinbase whatever the request looks like, so the
+one-M7-per-slot rule and the M7 encoding are not in scope for this rework.
+Second, if requests move off-chain entirely, all three M8 validation rules
+disappear along with the message — which is exactly the argument the companion
+proposal makes, and the reason it treats BIP-301's rejections as removable by
+design change rather than by deterministic resolution.
 
 ==Copyright==
 

--- a/bip301-unified.mediawiki
+++ b/bip301-unified.mediawiki
@@ -21,7 +21,7 @@ favour of the reference implementation and recorded in Appendix A with its
 evidence.
 
 ''A separate companion proposal,''
-[[#Companion proposal|Non-Invalidating Resolution for BIP-300/301]]'', argues
+[[bip301-unified-extended.mediawiki|Non-Invalidating Resolution for BIP-300/301]]'', argues
 that every block-rejection rule in this BIP could be eliminated by moving BMM
 payment off-chain. None of it is incorporated here. This document is the
 baseline against which that proposal should be read.''


### PR DESCRIPTION
## Summary

This PR adds unified BIP-300 and BIP-301 specifications that merge three sources
— the official BIPs, the specs in this repository, and the behaviour of
`bip300301_enforcer` — plus the analysis behind a follow-up proposal.

The three sources disagree in ways that would break an independent
implementation. Each conflict is resolved in favour of the reference
implementation, and every resolution is recorded in an Appendix A so the merge
can be audited rather than trusted.

**The unified specs propose no behavioural change.** Every rule that rejects a
block in the enforcer today still rejects a block in these documents.

## Files

| File | |
|---|---|
| `bip300-unified.mediawiki` | Unified BIP-300 |
| `bip301-unified.mediawiki` | Unified BIP-301 |
| `NON-INVALIDATING-RESOLUTION.md` | Analysis: which block rejections are necessary |
| `ENFORCER_INVALIDATEBLOCK.md` | Every invalidateblock path in the enforcer, with line references |

BIP mediawiki format is kept for the two specs because they are intended for
submission to `bitcoin/bips`. Happy to convert to `.md` for consistency with
`bip300.md` / `bip301.md` if preferred.

## Needs a decision: the M2 header byte

| Source | M2 header |
|---|---|
| Official BIP-300 | `D6 E1 C5 BF` |
| `bip300.md` (this repo) | `D6 E1 C5 BF` |
| `bip300301_enforcer` `lib/messages.rs:81` | `D6 E1 C5 DF` |

The implementation disagrees with both specifications on the final byte. Nothing
in the documents reveals which is correct. Anyone implementing from either spec
would emit M2 messages the enforcer ignores.

The unified spec follows the implementation and marks this **UNRESOLVED,
requires author input**. It should be settled before this is submitted upstream.

## Other reconciliations

| # | Item | Resolution |
|---|---|---|
| 1 | M6 output layout | All three sources differ; `bip300.md` contradicts itself (`vout[0]` when describing M6, "always the last output" when describing `m6_to_id`). Resolved: treasury at `vout[0]` in the final M6; fee `OP_RETURN` at `vout[0]` of the blinded form only, replaced by the treasury output. Only reading under which `M6ID` is computable before the treasury outpoint exists. |
| 2 | Unused-slot activation threshold | Original implies 1008/2016 (50% hashrate); this repo and the implementation use 1815 (90%). Adopted 1815 — flagged as a policy difference to confirm, not an editorial one. |
| 3 | Vote threshold comparison | Specs say "13150 or greater"; implementation compares strictly `>`. Adopted `>` — a bundle needs 13151 ACKs. |
| 4 | M2 structure | Original: 37 bytes, no slot byte. This repo: 38 bytes with slot. Adopted 38. |
| 5 | M3 blacklist | Original permanently bars any bundle hash ever paid out or rejected. Adopted this repo's rule: only *pending* hashes are barred. Removes an unbounded-state requirement and lets an expired bundle be retried. |
| 6 | Duplicate M1 / M3 scope | Original invalidates on any second M1 in a block, or second M3 per slot. Adopted the narrower rule: only exact duplicates (`(S, proposal_id)`, `(S, M6ID)`) invalidate. |
| 7 | M5 address `OP_RETURN` | Not required by the original; required here and enforced in code. Adopted as required. |
| 8 | Sidechain description | Original specifies structured fields; adopted opaque bytes, removing a parser from the consensus path. |
| 9 | BIP-301 `prevMainBlock` | Present in the original and enforced in code (`HandleM8::BmmRequestExpired`), absent from `bip301.md`'s validation rules. Restored. |
| 10 | M4 worked example | The original's example is internally inconsistent — labels a message "version 00" (which carries no vote array) while showing a two-element array. Dropped rather than repaired; this repo's indexing algorithm adopted. |

The three rules `bip300.md` marks with `???` (over-long vote array, out-of-range
bundle index, unnecessary two-byte encoding) are retained exactly as written. The
companion analysis argues for relaxing them; that argument is deliberately not
made in the specs.

## Companion analysis (no change proposed here)

`NON-INVALIDATING-RESOLUTION.md` maps all 29 conditions under which the enforcer
invalidates a block and asks which genuinely require rejection.

Motivation: every rejection rule is a point where a miner **not** running the
enforcer can fork the enforcer network off the chain — not necessarily
maliciously, simply by producing a block we refuse.

```
29 conditions today
-13  convertible now, by deterministic resolution
- 5  eliminated by specifying off-chain (Lightning) BMM
- 1  eliminated by making withdrawal approval sticky
 = 9 irreducible  (+ 1 unreachable)
```

The irreducible 9 are all facets of one rule: *a treasury UTXO may only be spent
by an M6 whose M6ID cleared the vote threshold, producing exactly one new
treasury.* They cannot be relaxed, and the reason is structural — `OP_DRIVECHAIN`
is `OP_NOP5 <push S> OP_TRUE`, which evaluates true with an empty scriptSig. The
treasury is anyone-can-spend to any node not enforcing BIP-300. Those rejections
do not enforce the peg; they **are** the peg.

Note on M8 specifically: resolving multiple M8s by picking a winner (first, or
highest fee) does **not** work. An M8 is an ordinary transaction, so the miner
collects every fee regardless of what the enforcer decides — selection makes the
fee harvest profitable rather than fatal. The only real fix is moving BMM payment
off-chain, which would remove all five BIP-301 rejections at once. That mechanism
is sketched in the original BIP-301 and specified nowhere.

Nothing in this analysis is applied to the specs in this PR.

## Review asks

1. **The M2 header byte** — spec bug or implementation bug?
2. **The 90% unused-slot threshold** (#2) — deliberate, or drift?
3. Are the resolutions in the table faithful to intended behaviour?
4. Should the specs be `.md` for repo consistency, or stay mediawiki for upstream
   submission?

## Notes

- The added `.md` files are oxfmt-clean and formatter-stable, so the format CI
  gate passes.
- `just fmt` calls `bunx`, so it needs bun installed locally;
  `npx oxfmt@0.58.0 .` is equivalent when bun is unavailable.
- If these are accepted, the intent is to propose the unified specs upstream to
  `bitcoin/bips` as an update to BIP-300/301.
